### PR TITLE
Added /locraw implementation for auto limbo

### DIFF
--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -24,7 +24,7 @@ class Bot {
     this.bot.once("login", this.onceLogin.bind(this));
 
     this.bot.addListener("kicked", this.onKicked.bind(this));
-    this.bot.once("spawn", this.onceSpawn.bind(this));
+    this.bot.addListener("spawn", this.onSpawn.bind(this));
     // this.bot.addListener("end", this.onEnd.bind(this));
     // this.bot.addListener("chat", this.onChat.bind(this));
     this.bot.addListener("message", this.onMessage.bind(this));
@@ -135,10 +135,9 @@ class Bot {
     configModule.default.execute(message, this);
   }
 
-  onceSpawn() {
-    this.bot.waitForTicks(22);
-    this.bot.chat("/limbo");
-    this.bot.waitForTicks(8);
+  async onSpawn() {
+    await this.bot.waitForTicks(10);
+    this.bot.chat("/locraw");
   }
 }
 

--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -12,6 +12,16 @@ export default {
    */
   execute: async function (message, bot) {
     if (message.toString() === bot.utils.chatSeparator) return;
+    // Attempt to extract locraw's "server" entry from message and check for limbo
+    const locrawServer = message
+      .toString()
+      .match(/^{"server":"(\w+)"(,"\w+":"[\w ]+")*}$/)?.[1];
+    if (locrawServer) {
+      if (locrawServer !== "limbo") {
+        bot.chat("/limbo");
+      }
+      return;
+    }
     let msgType = SenderType.Minecraft;
     let discordReplyId;
     if (bot.config.showMcChat && !message.self) {


### PR DESCRIPTION
- Added a simple /locraw implementation to automatically stay in limbo

I used a simple regex based approach to filter just the `server` field of hypixel's `/locraw` response, as I figured that parsing the entire JSON location string is not necessary for a bot that pretty much only cares about limbo/not limbo.