### PR TITLE
Added /locraw implementation for auto limbo

### DIFF
--- a/Config.example.mjs
+++ b/Config.example.mjs
@@ -30,5 +30,6 @@ export default {
     general: true,
     disableMinecraft: false,
     disableDiscord: false,
+    disableAutoLimbo: false
   },
 };

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -136,7 +136,9 @@ class Bot {
   }
 
   async onSpawn() {
-    await this.bot.waitForTicks(10);
+    await new Promise((resolve) =>
+      setTimeout(resolve, this.utils.minMsgDelay * 3),
+    );
     this.bot.chat("/locraw");
   }
 }

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -24,7 +24,7 @@ class Bot {
     this.bot.once("login", this.onceLogin.bind(this));
 
     this.bot.addListener("kicked", this.onKicked.bind(this));
-    this.bot.once("spawn", this.onceSpawn.bind(this));
+    this.bot.addListener("spawn", this.onSpawn.bind(this));
     // this.bot.addListener("end", this.onEnd.bind(this));
     // this.bot.addListener("chat", this.onChat.bind(this));
     this.bot.addListener("message", this.onMessage.bind(this));
@@ -135,10 +135,9 @@ class Bot {
     configModule.default.execute(message, this);
   }
 
-  onceSpawn() {
-    this.bot.waitForTicks(22);
-    this.bot.chat("/limbo");
-    this.bot.waitForTicks(8);
+  async onSpawn() {
+    await this.bot.waitForTicks(10);
+    this.bot.chat("/locraw");
   }
 }
 

--- a/src/mineflayer/commands/party/Ban.mjs
+++ b/src/mineflayer/commands/party/Ban.mjs
@@ -27,17 +27,14 @@ export default {
         bot.chat(`/p kick ${player}`);
         setTimeout(() => {
           bot.chat(`/block add ${player}`);
-          setTimeout(() => {
-            bot.chat(`/limbo`);
-            bot.webhook.send(
-              {
-                username: bot.config.webhook.name,
-              },
-              {
-                content: `\`${player}\` was banned from the party by \`${sender.username}\`. Reason: \`${reason}\``,
-              },
-            );
-          }, bot.utils.minMsgDelay);
+          bot.webhook.send(
+            {
+              username: bot.config.webhook.name,
+            },
+            {
+              content: `\`${player}\` was banned from the party by \`${sender.username}\`. Reason: \`${reason}\``,
+            },
+          );
         }, bot.utils.minMsgDelay);
       }, bot.utils.minMsgDelay);
     }, bot.utils.minMsgDelay);

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -21,18 +21,15 @@ export default {
       setTimeout(() => {
         bot.chat(`/block remove ${player}`);
         setTimeout(() => {
-          bot.chat(`/limbo`);
-          setTimeout(() => {
-            bot.reply(sender, `Unbanned ${player}.`);
-            bot.webhook.send(
-              {
-                username: bot.config.webhook.name,
-              },
-              {
-                content: `\`${player}\` was unbanned from the party by \`${sender.username}\`.`,
-              },
-            );
-          }, bot.utils.minMsgDelay);
+          bot.reply(sender, `Unbanned ${player}.`);
+          bot.webhook.send(
+            {
+              username: bot.config.webhook.name,
+            },
+            {
+              content: `\`${player}\` was unbanned from the party by \`${sender.username}\`.`,
+            },
+          );
         }, bot.utils.minMsgDelay);
       }, bot.utils.minMsgDelay);
     }, bot.utils.minMsgDelay);

--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -12,6 +12,16 @@ export default {
    */
   execute: async function (message, bot) {
     if (message.toString() === bot.utils.chatSeparator) return;
+    // Attempt to extract locraw's "server" entry from message and check for limbo
+    const locrawServer = message
+      .toString()
+      .match(/^{"server":"(\w+)"(,"\w+":"[\w ]+")*}$/)?.[1];
+    if (locrawServer) {
+      if (locrawServer !== "limbo") {
+        bot.chat("/limbo");
+      }
+      return;
+    }
     let msgType = SenderType.Minecraft;
     let discordReplyId;
     if (bot.config.showMcChat && !message.self) {

--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -17,7 +17,7 @@ export default {
       .toString()
       .match(/^{"server":"(\w+)"(,"\w+":"[\w ]+")*}$/)?.[1];
     if (locrawServer) {
-      if (locrawServer !== "limbo") {
+      if (locrawServer !== "limbo" && !bot.config.debug.disableAutoLimbo) {
         bot.chat("/limbo");
       }
       return;


### PR DESCRIPTION
- Added a simple /locraw implementation to automatically stay in limbo

I used a simple regex based approach to filter just the server field of hypixel's /locraw response, as I figured that parsing the entire JSON location string is not necessary for a bot that pretty much only cares about limbo/not limbo.

(I somehow messed up my first pr (#38 ) by renaming some branches in my fork, this is the reopened new pr with the same content as I couldn't get the old one to work again)