### PR TITLE
Automatic accepting party invites from trusted players

### DIFF
--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -22,7 +22,10 @@ export default {
       );
     }
     const partyInvite = bot.utils.findValidPartyInvite(message);
-    if (partyInvite) {
+    if (
+      partyInvite &&
+      !bot.partyCommands.find((value, key) => key.includes("invite")).disabled
+    ) {
       setTimeout(() => {
         bot.chat(`/p accept ${partyInvite}`);
       }, bot.utils.minMsgDelay);

--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -21,6 +21,12 @@ export default {
         bot.utils.classifyMessage(message.toString()),
       );
     }
+    const partyInvite = bot.utils.findValidPartyInvite(message);
+    if (partyInvite) {
+      setTimeout(() => {
+        bot.chat(`/p accept ${partyInvite}`);
+      }, bot.utils.minMsgDelay);
+    }
     if (message.self == true) {
       msgType = SenderType.Console;
       if (message.discord) {
@@ -48,8 +54,6 @@ export default {
         // also TODO: we do not have the username here, yet! Either move some
         // lines of code around so we do have it, or ignore for the time being
         // since we /r anyways currently
-        // also also TODO: i cant figure out the part where we run /p bingoparty and it accepts!
-        // someone please help me i am typing this at 2:42 in the morning and im going mental
         return bot.reply(
           "",
           "Read the documentation on GitHub: aphased/BingoPartyCommands",

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -2,6 +2,7 @@ import axios from "axios";
 import {
   DebugOptions,
   MessageType,
+  Permissions,
   WebhookMessageType,
 } from "./Interfaces.mjs";
 import { createLogger, format, transports } from "winston";
@@ -460,7 +461,7 @@ class Utils {
       ?.clickEvent?.value?.slice(14);
     if (
       inviteIGN &&
-      (this.getPermissionsByUser({ name: inviteIGN }) ?? 0) >= 2
+      (this.getPermissionsByUser({ name: inviteIGN }) ?? Permissions.ExSplasher) >= Permissions.Splasher
     ) {
       return inviteIGN;
     } else {

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -448,6 +448,26 @@ class Utils {
     else return WebhookMessageType.Other;
   }
 
+  /**
+   *
+   * @param {ChatMessage} message
+   * @returns {String|null}
+   */
+  findValidPartyInvite(message) {
+    // all clickable segments in the invite message have the same clickEvent, so we only care about the first one
+    const inviteIGN = message.extra
+      ?.find((obj) => obj.clickEvent?.value?.startsWith("/party accept "))
+      ?.clickEvent?.value?.slice(14);
+    if (
+      inviteIGN &&
+      (this.getPermissionsByUser({ name: inviteIGN }) ?? 0) >= 2
+    ) {
+      return inviteIGN;
+    } else {
+      return null;
+    }
+  }
+
   sendWebhookMessages() {
     let messageQueue = this.webhookLogger.messageQueue;
     messageQueue.forEach(async (value, key) => {


### PR DESCRIPTION
- Added automatic `/p accept` for party invites from trusted players (permissionRank >= 2)
- The bot won't automatically accept any invites if the `!p invite` command is disabled

This works by checking the `clickEvent`s of chat messages for the one present in a party invite message.
I don't think it'll be necessary to add some kind of check for whether the bot is already in a party (at least before we potentially implement the mod API), as the command will just fail without consequence.