### PR TITLE
`getCommandByAlias` utils function and small fix

### DIFF
--- a/src/mineflayer/commands/admin/DisableCommands.mjs
+++ b/src/mineflayer/commands/admin/DisableCommands.mjs
@@ -30,7 +30,7 @@ export default {
         );
       let commands = [];
       args.forEach((arg) => {
-        const found = bot.partyCommands.find((value, key) => key.includes(arg));
+        const found = bot.utils.getCommandByAlias(bot, arg);
         if (found) {
           commands.push(found);
         }

--- a/src/mineflayer/commands/admin/DisableCommands.mjs
+++ b/src/mineflayer/commands/admin/DisableCommands.mjs
@@ -18,7 +18,7 @@ export default {
     if (args[0] && args[0].toLowerCase() === "all") {
       bot.partyCommands.forEach((value, key) => {
         if (key.includes("disable") || key.includes("enable")) return;
-        bot.partyCommands.get(key).disabled = true;
+        value.disabled = true;
       });
       // TODO: also console log here
       bot.reply(sender, "All commands disabled!");
@@ -38,6 +38,11 @@ export default {
 
       if (commands.length !== args.length)
         return bot.reply(sender, "One or more command(s) not found.");
+      if (commands.some((cmd) => cmd.name.includes("disable") || cmd.name.includes("enable")))
+        return bot.reply(
+          sender,
+          "'!p enable' and '!p disable' are always enabled!",
+        );
       commands.forEach((cmd) => {
         cmd.disabled = true;
       });

--- a/src/mineflayer/commands/admin/EnableCommands.mjs
+++ b/src/mineflayer/commands/admin/EnableCommands.mjs
@@ -30,7 +30,7 @@ export default {
         );
       let commands = [];
       args.forEach((arg) => {
-        const found = bot.partyCommands.find((value, key) => key.includes(arg));
+        const found = bot.utils.getCommandByAlias(bot, arg);
         if (found) {
           commands.push(found);
         }

--- a/src/mineflayer/commands/admin/EnableCommands.mjs
+++ b/src/mineflayer/commands/admin/EnableCommands.mjs
@@ -18,7 +18,7 @@ export default {
     if (args[0] && args[0].toLowerCase() === "all") {
       bot.partyCommands.forEach((value, key) => {
         if (key.includes("disable") || key.includes("enable")) return;
-        bot.partyCommands.get(key).disabled = false;
+        value.disabled = false;
       });
       // TODO: also console log here
       bot.reply(sender, "All commands have been enabled!");
@@ -38,6 +38,11 @@ export default {
 
       if (commands.length !== args.length)
         return bot.reply(sender, "One or more command(s) not found.");
+      if (commands.some((cmd) => cmd.name.includes("disable") || cmd.name.includes("enable")))
+        return bot.reply(
+          sender,
+          "'!p enable' and '!p disable' are always enabled!",
+        );
       commands.forEach((cmd) => {
         cmd.disabled = false;
       });

--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -33,7 +33,7 @@ export default {
     const partyInvite = bot.utils.findValidPartyInvite(message);
     if (
       partyInvite &&
-      !bot.partyCommands.find((value, key) => key.includes("invite")).disabled
+      !bot.utils.getCommandByAlias(bot, "invite").disabled
     ) {
       setTimeout(() => {
         bot.chat(`/p accept ${partyInvite}`);
@@ -53,7 +53,7 @@ export default {
     }
     if (RegExp(/^From /g).test(message.toString())) {
       let command = message.toString().split(": ").slice(1).join(": "); // !p promo (lets say)
-      if (command.toLowerCase().startsWith("boop!"))
+      if (command.toLowerCase().startsWith("boop!") && !bot.utils.getCommandByAlias(bot, "invite").disabled)
         // TODO: this needs a settings toggle – if !p invite is disabled, this
         // shouldn't work either
         return bot.chat(

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -129,6 +129,15 @@ class Utils {
   }
 
   /**
+   * @param {import("../mineflayer/Bot.mjs").default} bot
+   * @param {string} commandAlias
+   * @returns {Object|null}
+   */
+  getCommandByAlias(bot, commandAlias) {
+    return bot.partyCommands.find((value, key) => key.includes(commandAlias));
+  }
+
+  /**
    * Retrieves a list of user accounts filtered by the specified permission
    * rank.
    *


### PR DESCRIPTION
- New `getCommandByAlias` function in Utils for easier (more readable) finding of commands in `bot.partyCommands`
- When bot receives 'Boop!', it now checks whether `!p invite` is enabled before sending a party invite
- Prevent disabling/enabling 'enable' and 'disable'
- Fixed unnecessary `partyCommands.get()` when value was already available