### PR TITLE
Command property `alwaysEnabled` and `!p listdisabled` command

### DIFF
--- a/src/mineflayer/commands/EXAMPLECOMMAND.mjs
+++ b/src/mineflayer/commands/EXAMPLECOMMAND.mjs
@@ -7,6 +7,7 @@ export default {
   permission: Permissions.Admin, // Permission level required to execute this command
   customPrefix: "", // Only use this if you want to use a custom prefix for this command, otherwise leave it empty and it'll use the default prefix
   isPartyChatCommand: false, // Set to true if the command should be used in party chat, also include the command's prefix (if applicable) in the name (e.g. '!guide')
+  alwaysEnabled: false, // Set to true for commands that should never be disabled (e.g. "!p disable")
   /**
    *
    * @param {import("../../Bot.mjs").default} bot

--- a/src/mineflayer/commands/admin/DisableCommands.mjs
+++ b/src/mineflayer/commands/admin/DisableCommands.mjs
@@ -5,6 +5,7 @@ export default {
   ignore: false, // Whether to ignore this file or not
   description: "Disables commands", // Description of the command
   permission: Permissions.Admin, // Permission level required to execute this command
+  alwaysEnabled: true,
   /**
    *
    * @param {import("../../Bot.mjs").default} bot
@@ -16,8 +17,8 @@ export default {
   execute: async function (bot, sender, args) {
     // Code here
     if (args[0] && args[0].toLowerCase() === "all") {
-      bot.partyCommands.forEach((value, key) => {
-        if (key.includes("disable") || key.includes("enable")) return;
+      bot.partyCommands.forEach((value) => {
+        if (value.alwaysEnabled) return;
         value.disabled = true;
       });
       // TODO: also console log here
@@ -38,10 +39,10 @@ export default {
 
       if (commands.length !== args.length)
         return bot.reply(sender, "One or more command(s) not found.");
-      if (commands.some((cmd) => cmd.name.includes("disable") || cmd.name.includes("enable")))
+      if (commands.some((cmd) => cmd.alwaysEnabled))
         return bot.reply(
           sender,
-          "'!p enable' and '!p disable' are always enabled!",
+          "One or more commands can't be disabled!",
         );
       commands.forEach((cmd) => {
         cmd.disabled = true;

--- a/src/mineflayer/commands/admin/EnableCommands.mjs
+++ b/src/mineflayer/commands/admin/EnableCommands.mjs
@@ -5,6 +5,7 @@ export default {
   ignore: false, // Whether to ignore this file or not
   description: "Enables commands so they can be run using !p command", // Description of the command
   permission: Permissions.Admin, // Permission level required to execute this command
+  alwaysEnabled: true,
   /**
    *
    * @param {import("../../Bot.mjs").default} bot
@@ -16,8 +17,8 @@ export default {
   execute: async function (bot, sender, args) {
     // Code here
     if (args[0] && args[0].toLowerCase() === "all") {
-      bot.partyCommands.forEach((value, key) => {
-        if (key.includes("disable") || key.includes("enable")) return;
+      bot.partyCommands.forEach((value) => {
+        if (value.alwaysEnabled) return;
         value.disabled = false;
       });
       // TODO: also console log here
@@ -38,10 +39,10 @@ export default {
 
       if (commands.length !== args.length)
         return bot.reply(sender, "One or more command(s) not found.");
-      if (commands.some((cmd) => cmd.name.includes("disable") || cmd.name.includes("enable")))
+      if (commands.some((cmd) => cmd.alwaysEnabled))
         return bot.reply(
           sender,
-          "'!p enable' and '!p disable' are always enabled!",
+          "One or more commands are always enabled!",
         );
       commands.forEach((cmd) => {
         cmd.disabled = false;

--- a/src/mineflayer/commands/admin/ListDisabledCommands.mjs
+++ b/src/mineflayer/commands/admin/ListDisabledCommands.mjs
@@ -1,0 +1,46 @@
+import { Permissions } from "../../../utils/Interfaces.mjs";
+
+export default {
+  name: ["listdisabled", "disabled"], // This command will be triggered by either command1 or command2
+  ignore: false, // Whether to ignore this file or not
+  description: "Lists disabled commands", // Description of the command
+  permission: Permissions.Admin, // Permission level required to execute this command
+  alwaysEnabled: true,
+  /**
+   *
+   * @param {import("../../Bot.mjs").default} bot
+   * @param {Object} sender
+   * @param {String} [sender.username] - Username of the sender
+   * @param {String} [sender.preferredName] - Preferred name of the sender
+   * @param {Array<String>} args
+   */
+  execute: async function (bot, sender, args) {
+    let disabledCommands = [];
+    let enabledCommands = [];
+    bot.partyCommands.forEach((value, key) => {
+      if (value.alwaysEnabled) return;
+      if (value.disabled) disabledCommands.push(key[0]);
+      else enabledCommands.push(key[0]);
+    });
+
+    if (disabledCommands.length < 1)
+      return bot.reply(sender, "All commands are enabled!");
+    if (enabledCommands.length < 1)
+      return bot.reply(
+        sender,
+        "All commands are disabled (except ones that can't be disabled)",
+      );
+    // if there are more disabled commands than enabled ones, list only the enabled ones to avoid hitting the chat limit
+    // this will probably only be a handful of commands in the majority of cases (e.g. "!p test" and "!p link" outside of bingo)
+    if (disabledCommands.length > enabledCommands.length)
+      bot.reply(
+        sender,
+        `All commands are currently disabled, except: ${enabledCommands.join(", ")}`,
+      );
+    else
+      bot.reply(
+        sender,
+        `Currently disabled commands: ${disabledCommands.join(", ")}`,
+      );
+  },
+};


### PR DESCRIPTION
- Added optional command property `alwaysEnabled` to standardise blocking commands from being disabled
- Added `!p listdisabled` command to list currently disabled commands
  - Doesn't list commands if all of them are enabled/disabled
  - Ignores commands with the `alwaysEnabled = true` property
  - Lists enabled commands instead if there are more disabled than enabled ones (to prevent hitting chat limits)
  - Same permission req as `!p enable/disable`