### PR TITLE
User db improvements (uuid based system), related commands and optimisations in utils, db update script

### DIFF
--- a/Config.example.mjs
+++ b/Config.example.mjs
@@ -25,11 +25,13 @@ export default {
   },
   guideLink: "", // I advise you to keep this empty, and just use discord commands to set the guide link or the guide channel.
   showMcChat: true,
+  usernameRefreshInterval: 2 * 60 * 60 * 1000, // in milliseconds, default is 2h (2 * 60 * 60 * 1000ms)
   debug: {
     // IF YOU DONT KNOW WHAT YOU ARE DOING DO NOT TOUCH THIS. THIS IS MADE FOR DEVELOPERS TO DEBUG THE BOT ONLY
     general: true,
     disableMinecraft: false,
     disableDiscord: false,
-    disableAutoLimbo: false
+    disableAutoLimbo: false,
+    disableUsernameRefresh: false,
   },
 };

--- a/one-time-scripts/convert-data-util_old.mjs
+++ b/one-time-scripts/convert-data-util_old.mjs
@@ -1,9 +1,9 @@
 import JSONdb from "simple-json-db";
 // import * as players from "./data/playerNamesOldFormat.json" assert { type: "json" };
-import * as players from "./data/playerNamesOldFormat.json" with { type: "json" };
+import * as players from "../data/playerNamesOldFormat.json" with { type: "json" };
 import axios from "axios";
 
-let db = new JSONdb("./data/playerNamesUpdatedFormat.json");
+let db = new JSONdb("../data/playerNamesUpdatedFormat.json");
 db.set("players", []);
 
 function delay(ms) {

--- a/one-time-scripts/updatedb-preferredAccount.mjs
+++ b/one-time-scripts/updatedb-preferredAccount.mjs
@@ -15,7 +15,7 @@ let data = db.get("data");
 
 if (!data) {
   console.log(
-    "Coudldn't load playerNames database file! Make sure data/playerNames.json exists and contains player data!",
+    "Couldn't load playerNames database file! Make sure data/playerNames.json exists and contains player data!",
   );
   process.exit(1);
 }

--- a/one-time-scripts/updatedb-preferredAccount.mjs
+++ b/one-time-scripts/updatedb-preferredAccount.mjs
@@ -1,0 +1,96 @@
+// quick script to update playerNames db to the new preferredAccount system, also enforce correct uuids and names
+// new db file will be generated as "playerNamesUpdated.json"
+// if any errors are logged, investigate their origin before using the generated data
+
+import JSONdb from "simple-json-db";
+import axios from "axios";
+import * as path from "path";
+const __dirname = import.meta.dirname;
+
+// path import needed for parent dir ("..")
+let db = new JSONdb(
+  path.join(__dirname, "..", "data", "playerNames.json"),
+);
+let data = db.get("data");
+
+if (!data) {
+  console.log(
+    "Coudldn't load playerNames database file! Make sure data/playerNames.json exists and contains player data!",
+  );
+  process.exit(1);
+}
+
+const startTimestamp = Date.now();
+
+let newData = [];
+
+for (let i = 0; i < data.length; i++) {
+  let user = data[i];
+  let newUser = { accounts: [], permissionRank: user.permissionRank };
+
+  // making sure all accounts are valid, have uuids and correctly capitalised usernames
+  for (let acc of user.accounts) {
+    let errtype;
+    if (!acc.uuid) {
+      try {
+        const response = await axios.get(
+          `https://api.mojang.com/users/profiles/minecraft/${acc.name}`,
+        );
+        acc.name = response.data.name;
+        acc.uuid = response.data.id;
+      } catch (err) {
+        if (err?.response?.status === 404)
+          errtype = "data"; // invalid account data
+        else errtype = "request"; // request failed (network of rate limit)
+        // console.log(err)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000)); // this endpoint's rate limit seems to be ~30/min
+    } else {
+      // use uuid based api endpoint to validate username if possible (accounts for name changes, also much higher rate limit)
+      try {
+        const response = await axios.get(
+          `https://sessionserver.mojang.com/session/minecraft/profile/${acc.uuid}`,
+        );
+        acc.name = response.data.name;
+      } catch (err) {
+        if (err?.response?.status === 400)
+          errtype = "data"; // invalid account data
+        else errtype = "request"; // request failed (network or rate limit)
+        // console.log(err)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100)); // this endpoint's rate limit seems to be exactly 1700/min
+    }
+    if (errtype) {
+      if (errtype === "request")
+        console.log(
+          // rate limit or other network/request issue
+          `API request error while getting info for account ${acc.name} (uuid: ${acc.uuid})`,
+        );
+      else if (errtype === "data")
+        // name likely changed and storing uuids wasn't enforced
+        console.log(`Invalid account data, skipping: ${acc.name} (uuid: ${acc.uuid})`);
+      continue; // skip account
+    }
+    if (newUser.accounts.some((a) => a.uuid === acc.uuid))
+      console.log(`Removing duplicate account ${acc.name} (uuid: ${acc.uuid})`);
+    else newUser.accounts.push(acc);
+  }
+  if (newUser.accounts.length < 1) continue;
+  // if possible, migrate preferredName to preferredAccount
+  if (user.preferredName) {
+    const preferredAcc = newUser.accounts.find(
+      (acc) => acc.name.toLowerCase() === user.preferredName.toLowerCase(),
+    );
+    if (preferredAcc) newUser.preferredAccount = preferredAcc.uuid;
+  }
+  if (user.discord) newUser.discord = user.discord;
+  // preferredAccount, hideRank and hypixelRank per account can be left empty to automatically be set when a party command is sent
+
+  newData.push(newUser);
+}
+
+let newDB = new JSONdb(path.join(__dirname, "..", "data", "playerNamesUpdated.json"),);
+newDB.set("data", newData);
+
+const secondsElapsed = Math.round(Date.now()/10-startTimestamp/10)/100;
+console.log(`Finished updating database in ${secondsElapsed}s! New db saved as "data/playerNamesUpdated.json".`)

--- a/src/discord/components/commands/RunCommand.mjs
+++ b/src/discord/components/commands/RunCommand.mjs
@@ -26,11 +26,15 @@ export default {
     if (!command)
       return interaction.editReply("You need to provide a command to run!");
     bot.utils.discordReply.setReply(replyId, interaction);
-    let user = bot.utils.getUserObject({ discord: interaction.user.id });
-    if (!user)
-      return interaction.editReply("You need to link your account first!");
+    let preferredName = bot.utils.getPreferredUsername({
+      discord: interaction.user.id,
+    });
+    if (!preferredName)
+      return interaction.editReply(
+        "You need to link your account first using `/link` and `!p link` in-game!",
+      );
     myBot.onMessage({
-      content: `From ${user.hypixelRank} ${user.accounts[0].name}: ${command}`,
+      content: `From ${preferredName}: ${command}`,
       self: true,
       discord: true,
       discordReplyId: replyId,

--- a/src/mineflayer/commands/admin/GetUser.mjs
+++ b/src/mineflayer/commands/admin/GetUser.mjs
@@ -17,30 +17,26 @@ export default {
    */
   execute: async function (bot, sender, args) {
     let user = args[0];
-    if (!user || user.length == 0) {
+    if (!user) {
       return bot.reply(
         sender,
         "Please provide a user to query/get permissions for.",
       );
     }
-    let uuid = await bot.utils.getUUID(user);
-    if (!uuid) return bot.reply(sender, "User not found!");
-    let playerNames = bot.utils.playerNamesDatabase.get("data");
-    let index = playerNames.findIndex((x) =>
-      x.accounts.find((y) => y.uuid === uuid),
-    );
-    if (index === -1)
+    let userObj = bot.utils.getUserObject({ name: user });
+    if (!userObj)
       return bot.reply(
         sender,
         "That person does not have any party permissions.",
       );
-    let userObj = playerNames[index];
-    let rank = Object.keys(Permissions).find(
-      (x) => Permissions[x] === userObj.permissionRank,
+    const rank = Object.keys(Permissions).find(
+      (perm) => Permissions[perm] === userObj.permissionRank,
     );
+    // Get name with correct capitalisation
+    const name = userObj.accounts.find((acc) => acc.name.toLowerCase() === user.toLowerCase()).name;
     bot.reply(
       sender,
-      `User: ${user} Rank: ${rank} (Level: ${userObj.permissionRank})`,
+      `User: ${name} Rank: ${rank} (Level: ${userObj.permissionRank})`,
     );
   },
 };

--- a/src/mineflayer/commands/admin/RemoveUser.mjs
+++ b/src/mineflayer/commands/admin/RemoveUser.mjs
@@ -1,6 +1,4 @@
 import { Permissions } from "../../../utils/Interfaces.mjs";
-import Utils from "../../../utils/Utils.mjs";
-import loadPartyCommands from "../../handlers/PartyCommandHandler.mjs";
 
 export default {
   name: ["removeuser"],
@@ -15,23 +13,12 @@ export default {
    */
   execute: async function (bot, sender, args) {
     let user = args[0];
-    let type = args[1];
-    let uuid = await bot.utils.getUUID(user);
-    // TODO: attempt to try it based on username one time if UUID fails?
-    if (!uuid) return bot.reply(sender, `User ${user} not found!`);
-    let playerNames = bot.utils.playerNamesDatabase.get("data");
-    let index = playerNames.findIndex((x) =>
-      x.accounts.find((y) => y.uuid === uuid),
-    );
-    if (index === -1) return bot.reply(sender, "User does not exist!");
-    if (type && type == "only") {
-      playerNames[index].accounts = playerNames[index].accounts.filter(
-        (x) => x.uuid !== uuid,
-      );
-    } else {
-      playerNames.splice(index, 1);
-    }
-    bot.utils.playerNamesDatabase.set("data", playerNames);
-    bot.reply(sender, `Removed user ${user}`);
+    let only = args[1]?.toLowerCase?.() === "only";
+    if (!bot.utils.getUserObject({ name: user }))
+      return bot.reply(sender, `User ${user} not found in database!`);
+    bot.utils.removeUser({ name: user, onlyThis: only });
+    if (only)
+      return bot.reply(sender, `Removed account ${user}, but kept other alts.`);
+    bot.reply(sender, `Removed user ${user}.`);
   },
 };

--- a/src/mineflayer/commands/admin/RemoveUser.mjs
+++ b/src/mineflayer/commands/admin/RemoveUser.mjs
@@ -14,11 +14,16 @@ export default {
   execute: async function (bot, sender, args) {
     let user = args[0];
     let only = args[1]?.toLowerCase?.() === "only";
+    if (!user)
+      return bot.reply(
+        sender,
+        'Please supply a username to remove! You can choose to keep the person\'s other accounts by appending "only".',
+      );
     if (!bot.utils.getUserObject({ name: user }))
       return bot.reply(sender, `User ${user} not found in database!`);
     bot.utils.removeUser({ name: user, onlyThis: only });
     if (only)
       return bot.reply(sender, `Removed account ${user}, but kept other alts.`);
-    bot.reply(sender, `Removed user ${user}.`);
+    bot.reply(sender, `Removed user ${user} and all their other accounts.`);
   },
 };

--- a/src/mineflayer/commands/admin/UpdateUsernames.mjs
+++ b/src/mineflayer/commands/admin/UpdateUsernames.mjs
@@ -1,0 +1,54 @@
+import { Permissions } from "../../../utils/Interfaces.mjs";
+
+export default {
+  name: ["updatenames", "refreshnames"],
+  ignore: false,
+  description: "Manually triggers a username refresh from UUIDs",
+  permission: Permissions.Owner,
+  /**
+   *
+   * @param {import("../../Bot.mjs").default} bot
+   * @param {String} sender
+   * @param {Array<String>} args
+   */
+  execute: async function (bot, sender, args) {
+    if (args[0] !== "confirm") {
+      let sinceLast = Math.round(
+        (Date.now() -
+          (bot.utils.generalDatabase.get("lastUsernameRefresh") ?? 0)) /
+          60_000,
+      );
+      let toNext =
+        Math.round(bot.config.usernameRefreshInterval / 60_000) - sinceLast;
+      if (toNext < 0) toNext = "<1";
+      return bot.reply(
+        sender,
+        `The last refresh happened ${sinceLast} minute(s) ago. The next one will happen in ${toNext} minute(s). If you want to manually trigger one, run \"!p updatenames confirm\".`,
+      );
+    }
+    bot.reply(sender, "Started username refresh!");
+    // cancel previously scheduled refresh
+    clearTimeout(bot.utils.scheduledUsernameRefresh);
+    // initiate manual refresh
+    const results = await bot.utils.updateAllFromUUID(bot);
+    // schedule next automatic refresh
+    bot.utils.scheduledUsernameRefresh = setTimeout(
+      bot.utils.updateAllFromUUID.bind(bot.utils),
+      bot.config.usernameRefreshInterval,
+      bot,
+    );
+    const intervalInMin = Math.round(
+      bot.config.usernameRefreshInterval / 60_000,
+    );
+    if (results.failed === 0)
+      bot.reply(
+        sender,
+        `Successfully updated all stored username in ${results.timeTaken}s! Next automatic refresh scheduled in ${intervalInMin} minutes.`,
+      );
+    else
+      bot.reply(
+        sender,
+        `Failed to update ${results.failed} usernames! Check logs for details. Next automatic refresh scheduled in ${intervalInMin} minutes.`,
+      );
+  },
+};

--- a/src/mineflayer/commands/misc/HideRank.mjs
+++ b/src/mineflayer/commands/misc/HideRank.mjs
@@ -1,0 +1,41 @@
+import { Permissions } from "../../../utils/Interfaces.mjs";
+
+export default {
+  name: ["hiderank", "hr", "togglerank"],
+  ignore: false,
+  description:
+    "Toggle between hiding and showing your rank in output of party commands (e.g. !p say)",
+  permission: Permissions.Splasher,
+  /**
+   *
+   * @param {import("../../Bot.mjs").default} bot
+   * @param {String} sender
+   * @param {Array<String>} args
+   */
+  execute: async function (bot, sender, args) {
+    if (!bot.utils.getUserObject({ name: sender.username }))
+      return bot.reply(
+        sender,
+        "How are you even able to run this without being in the db??",
+      );
+    let newSetting = args[0]?.toLowerCase?.();
+    let currentSetting = !!bot.utils.getUserObject({ name: sender.username })
+      .hideRank;
+    if (newSetting === "true" || newSetting === "false")
+      newSetting = newSetting === "true";
+    else newSetting = !currentSetting;
+    if (newSetting === currentSetting)
+      return bot.reply(
+        sender,
+        `Your rank is already being ${newSetting ? "hidden" : "shown"} in the output of party commands!`,
+      );
+    bot.utils.setHideRankSetting({
+      name: sender.username,
+      hideRank: newSetting,
+    });
+    bot.reply(
+      sender,
+      `Your rank is now ${newSetting ? "hidden" : "shown"} in the output of party commands!`,
+    );
+  },
+};

--- a/src/mineflayer/commands/misc/PreferredName.mjs
+++ b/src/mineflayer/commands/misc/PreferredName.mjs
@@ -12,22 +12,22 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    const usernames = bot.utils
-      .getUserObject({ name: sender.username })
-      ?.accounts?.map((acc) => acc.name);
-    if (!usernames)
+    let availableAccs = bot.utils.getUserObject({
+      name: sender.username,
+    })?.accounts;
+    if (!availableAccs)
       return bot.reply(
         sender,
         "How are you even able to run this without being in the db??",
       );
-    // attempt to get the requested username with correct capitalisation
-    const requestedName = usernames.find(
-      (name) => name?.toLowerCase() === args[0]?.toLowerCase(),
+    // get account object with supplied username (case-insensitive)
+    const account = availableAccs.find(
+      (obj) => obj.name.toLowerCase() === args[0]?.toLowerCase?.(),
     );
-
+    
     // no name supplied or not a valid option
-    if (!requestedName) {
-      const message = `Your current preferred name is: ${sender.preferredName}. Set it to one of your other accounts' igns: ${usernames.join(", ")}`;
+    if (!account) {
+      const message = `Your current preferred name is: ${sender.preferredName}. Set it to any one of your ${availableAccs.length} accounts' igns: ${availableAccs.map((obj) => obj.name).join(", ")}`;
       if (message.length > 252) {
         const splitIndex = message.slice(0, 253).lastIndexOf(" ");
         bot.reply(sender, message.slice(0, splitIndex));
@@ -39,10 +39,10 @@ export default {
       }
       return bot.reply(sender, message);
     }
-    bot.utils.setPreferredUsername({
+    bot.utils.setPreferredAccount({
       name: sender.username,
-      newName: requestedName,
+      preferredAccount: account.uuid,
     });
-    bot.reply(sender, `Your preferred name has been set to ${requestedName}.`);
+    bot.reply(sender, `Your preferred name has been set to ${account.name}.`);
   },
 };

--- a/src/mineflayer/commands/misc/Test.mjs
+++ b/src/mineflayer/commands/misc/Test.mjs
@@ -5,8 +5,10 @@ export default {
   ignore: false,
   description:
     "Test command. See if you are on the permission list, and what permissions you have",
+  // command can't have a permission requirement, otherwise any uuid fetching here is pointless as db permission checks would prevent it from executing in the first place
+  // there still isn't any output without being in the db
+
   // One day this will also have ban info? maybe?
-  permission: Permissions.ExSplasher,
   /**
    *
    * @param {import("../../Bot.mjs").default} bot
@@ -14,30 +16,22 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    // previous implementation:
-    /* let userPerms = bot.utils.getPermissionsByUser({ name: sender.username });
-    if (userPerms) {
-      bot.reply(sender, `You have permission level: ${userPerms}`);
-    } */
-
     let uuid = await bot.utils.getUUID(sender.username);
-    if (!uuid) return bot.reply(sender, "whad.");
-    let playerNames = bot.utils.playerNamesDatabase.get("data");
-    let index = playerNames.findIndex((x) =>
-      x.accounts.find((y) => y.uuid === uuid),
-    );
-    if (index === -1)
-      return bot.reply(
-        sender,
-        "wait how do you manage to run this and get the no perms output what",
-      );
-    let userObj = playerNames[index];
-    let rank = Object.keys(Permissions).find(
-      (x) => Permissions[x] === userObj.permissionRank,
+    let permissionRank;
+    if (uuid) permissionRank = bot.utils.getPermissionsByUser({ uuid: uuid });
+    // if uuid fetching fails, try with username
+    else
+      permissionRank = bot.utils.getPermissionsByUser({
+        name: sender.username,
+      });
+    if (!permissionRank)
+      return;
+    const permission = Object.keys(Permissions).find(
+      (perm) => Permissions[perm] === permissionRank,
     );
     bot.reply(
       sender,
-      `You have permissions! Your permission level is ${rank} (Level: ${userObj.permissionRank})`,
+      `You have permissions! Your permissions are ${permission} (Level: ${permissionRank})`,
     );
   },
 };

--- a/src/mineflayer/commands/party/Guide.mjs
+++ b/src/mineflayer/commands/party/Guide.mjs
@@ -54,16 +54,15 @@ export default {
       // Prevent _ever_ outputting empty "Party > [MVP++] BingoParty: Guide: "
       console.log("Absolutely no guide available!");
       if (!isPublicCommand) {
-        /* We really only expect to get one relevant entry (corresponding to the
-          actual person) with owner permission, so taking the first object from
-          the result is ok. After that, we can try again if preferredName isn't
-          set (i.e., returns null) by taking the first in-game accounts' name */
-        const botAccountOwner =
-          bot.utils.getUsersByPermissionRank(Permissions.Owner)?.[0]
-            ?.preferredName ??
-          bot.utils.getUsersByPermissionRank(Permissions.Owner)?.[0]
-            ?.accounts?.[0]?.name ??
-          null;
+        // `Permissions.BotAccount === Permissions.Owner`, so the bot has to be filtered out first
+        // Then take the first remaining user, as only one owner is expected
+        const botAccountOwner = bot.utils.getPreferredUsername({
+          name: bot.utils
+            .getUsersByPermissionRank(Permissions.Owner)
+            .find(
+              (obj) => !obj.accounts.some((acc) => acc.name === bot.username),
+            )?.accounts?.[0]?.name,
+        });
 
         bot.reply(
           sender,

--- a/src/mineflayer/events/OnceLogin.mjs
+++ b/src/mineflayer/events/OnceLogin.mjs
@@ -20,14 +20,14 @@ export default {
       );
       bot.utils.playerNamesDatabase.set("data", []);
       bot.utils.addUser({
-              name: bot.username,
-              uuid: await bot.utils.getUUID(bot.username),
-          permissionRank: Permissions.BotAccount,
+        name: bot.username,
+        uuid: await bot.utils.getUUID(bot.username),
+        permissionRank: Permissions.BotAccount,
       });
       bot.utils.addUser({
-              name: "YOUR USERNAME",
-              uuid: "YOUR UUID",
-          permissionRank: Permissions.Owner,
+        name: "YOUR USERNAME",
+        uuid: "YOUR UUID",
+        permissionRank: Permissions.Owner,
       });
       setTimeout(() => {
         bot.utils.log("Added Bot account to database", "Info");
@@ -43,8 +43,8 @@ export default {
     });
     if (!permissionRank) {
       bot.utils.addUser({
-              name: bot.username,
-              uuid: await bot.utils.getUUID(bot.username),
+        name: bot.username,
+        uuid: await bot.utils.getUUID(bot.username),
         permissionRank: Permissions.BotAccount,
       });
       bot.utils.log("Bot account added to database", "Info");
@@ -64,5 +64,19 @@ export default {
         content: "Logged in! `(" + bot.username + ")`",
       },
     );
+    // schedule first refresh of usernames from UUID
+    if (!bot.config.debug.disableUsernameRefresh) {
+      const lastRefresh = bot.utils.generalDatabase.get("lastUsernameRefresh");
+      let scheduleTime =
+        bot.config.usernameRefreshInterval - (Date.now() - (lastRefresh ?? 0));
+      // delay the refresh for 1min if it has been due/is due soon to avoid overloading the bot on startup
+      if (scheduleTime < 60_000) scheduleTime = 60_000;
+      // save timeout ID to be able to reschedule the refresh when updating manually (!p updatenames)
+      bot.utils.scheduledUsernameRefresh = setTimeout(
+        bot.utils.updateAllFromUUID.bind(bot.utils),
+        scheduleTime,
+        bot,
+      );
+    }
   },
 };

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -397,7 +397,7 @@ class Utils {
    * @param {Object} options
    * @param {String} [options.uuid]
    * @param {String} [options.name]
-   * @param {String} [options.newName]
+   * @param {String} [options.hideRank]
    * @returns
    */
   setHideRankSetting(options = {}) {

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -319,8 +319,12 @@ class Utils {
       userObj.accounts = userObj.accounts.filter(
         (acc) => acc.name.toLowerCase() !== options.name.toLowerCase(),
       );
-      // reset preferredAccount to prevent having a removed uuid stored
-      delete userObj.preferredAccount;
+      // reset preferredAccount if it's the removed account
+      if (
+        userObj.accounts.find((acc) => acc.name === options.name).uuid ===
+        userObj.preferredAccount
+      )
+        delete userObj.preferredAccount;
       db[db.indexOf(userObj)] = userObj;
     }
     // Remove the entire user
@@ -345,9 +349,7 @@ class Utils {
         (acc) => acc.name.toLowerCase() === options.name.toLowerCase(),
       );
       const uuid = userObj.accounts[index].uuid;
-      const username = await this.getUsername(
-        userObj.accounts[index].uuid,
-      );
+      const username = await this.getUsername(userObj.accounts[index].uuid);
       if (!username) return [uuid];
       db[db.indexOf(userObj)].accounts[index].name = username;
     } else {
@@ -577,8 +579,7 @@ class Utils {
     if (!userObj) return null;
     return userObj.accounts.find(
       (acc) =>
-        (options.uuid &&
-          acc.uuid === options.uuid?.toLowerCase?.()) ||
+        (options.uuid && acc.uuid === options.uuid?.toLowerCase?.()) ||
         (options.name &&
           acc.name.toLowerCase() === options.name?.toLowerCase?.()),
     )?.hypixelRank;
@@ -599,11 +600,11 @@ class Utils {
       (acc) =>
         (options.uuid &&
           acc.uuid.toLowerCase() === options.uuid.toLowerCase()) ||
-        (options.name &&
-          acc.name.toLowerCase() === options.name.toLowerCase()),
-    )
+        (options.name && acc.name.toLowerCase() === options.name.toLowerCase()),
+    );
     account.hypixelRank = options.hypixelRank;
-    db[db.indexOf(userObj)].accounts[userObj.accounts.indexOf(account)] = account;
+    db[db.indexOf(userObj)].accounts[userObj.accounts.indexOf(account)] =
+      account;
     this.playerNamesDatabase.set("data", db);
   }
 


### PR DESCRIPTION
- Updated player db format
  - ~~`preferredName`~~ `preferredAccount` now stores the uuid of the preferred account
  - `hypixelRank` is now a property of each account, instead of the entire player
    - Updates upon running any party command
  - New per-player `hideRank` value, stores whether the user prefers their hypixel rank to be included in preferred name
    - defaults to showing ranks (few people will probably change it)
- `!p preferredname` (`!p name`) now stores the uuid after you select which account's name you prefer
- `!p hiderank` lets you toggle hiding the hypixel rank in preferred name
  - Either run `!p hiderank <true|false>` to set value, or toggle by not supplying `true` or `false`
- `!p adduser` (and `!p removeuser`) now run on util functions that can be accessed from other parts of the bot (e.g. adding bot acc upon initial loading)
  - Also added more useful command feedback messages
  - Clears `preferredAccount` when it's the removed account, to prevent storing the removed info
  - Now corrects username capitalisation (in the same go as fetching the uuid!) before adding account to db
- `!p test` now runs for anyone, but doesn't reply, unless you have permissions
  - Without this change, checking UUID for updated username would be pointless as the command wouldn't be executed in the first place
- Optimisations and removing duplicate code
  - Changed all util functions (and some other logic) that fetch player data to use `getPlayerObject` to avoid duplicate code
  - Merged DM and party chat logic in `MessageEvent.mjs` as much as possible
  - Renamed the `getUsername` utils function (the one that extracts the username from incoming messages) to `extractUsername` to avoid duplicating function names
  - Likewise added `extractHypixelRank`, which extracts the rank from an incoming message
  - Some other smaller optimisations in `Utils.mjs` and others
- The bot now automatically updates its database of usernames from UUIDs on an interval
  - Added debug config option `disableUsernameRefresh` to disable this
  - Added config value `usernameRefreshInterval` (defaults to 2h)
    - The UUID to username endpoint seems to have a 1700/min rate limit, from my testing, which should be *plenty* for any purpose
    - There is an additional delay of 100ms between each API request to spread the traffic out a bit
  - The bot stores a timestamp of the last refresh in `generalDatabase` for persistent scheduling
  - The first refresh is scheduled on bot start
    - Based on the last refresh's timestamp and the interval, never in the first 60s of the bot running
  - Added `!updatenames` command to get info about scheduling or manually trigger a refresh by appending `confirm` (`!p updatenames confirm`)
    - If a manual refresh is initiated, the next automatic one is rescheduled accordingly
- Wrote a one-time db update script to run on the `playerNames.json` db for these changes
  - These one-time scripts now have a directory of their own
  - Removes accounts without uuid that it can't get an uuid for (name changed)
    - Re-add those manually using `!p adduser`, after looking up the updated username from [namemc](https://namemc.com) or similar
  - Removes duplicate entries (emaia had 3??)
  - Resets `preferredName` and `hypixelRank` (those get re-added when the user sends a party command)
  - Removed accounts get logged to console for manual verification/re-adding in some cases
  - Note: **Don't** manually edit the db under any circumstance to prevent issues (bot handles things like enforcing an uuid is present)
 
Hope I didn't forget anything :)