### PR TITLE
Bridge message filtering, message order fix, main action log is now a `WebhookMessageType`

### DIFF
--- a/Config.example.mjs
+++ b/Config.example.mjs
@@ -6,21 +6,21 @@ export default {
     authType: "microsoft",
     email: "EMAIL OF ACCOUNT HERE",
   },
-  webhook: {
-    // TODO: add support for multiple URLS here too, just like for bridge
-    url: "WEBHOOK API URL HERE", // This is for main bot logging
-    name: "BingoParty Bridge",
-    avatarUrl: "",
-    bridge: [
-      {
-        // These are for ingame logging, check the WebhookMessageType interface in src/utils/Interfaces.mjs for more info
-        webhookUrl: "",
-        messageType: WebhookMessageType.All,
-      },
-    ],
-  },
+  webhooks: [
+    {
+      // Bingo Party main action logs
+      webhookUrl: "", // Add a webhook url here
+      messageType: WebhookMessageType.ActionLog,
+    },
+    {
+      // Default bridge configuration
+      webhookUrl: "", // Add a webhook url here
+      messageType: WebhookMessageType.Bridge,
+    },
+    // Add more webhooks as needed, check the WebhookMessageType interface in src/utils/Interfaces.mjs for more info
+  ],
   discordBotInfo: {
-    token: "DISCORD BOT TOKEN HERE (or empty string)",
+    token: "", // Add discord bot token here (or leave empty for operation without bot)
     guideChannel: "ID for the channel which has bingo guide links",
   },
   guideLink: "", // I advise you to keep this empty, and just use discord commands to set the guide link or the guide channel.

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -106,7 +106,7 @@ class Bot {
     this.config = config;
     if (this.config.guideLink)
       this.utils.setMonthGuide({ link: this.config.guideLink });
-    this.utils.webhookLogger.setWebhooks(this.config.webhook.bridge);
+    this.utils.webhookLogger.setWebhooks(this.config.webhooks);
   }
 
   /*

--- a/src/mineflayer/commands/party/AllInvite.mjs
+++ b/src/mineflayer/commands/party/AllInvite.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["allinvite", "allinv", "ai"], // This command will be triggered by either command1 or command2
@@ -15,13 +15,10 @@ export default {
     bot.chat(`/pc ${sender.preferredName} toggled the All Invite setting.`);
     setTimeout(() => {
       bot.chat("/p settings allinvite");
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `\`${sender.preferredName}\` toggled the All Invite party setting.`,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `\`${sender.preferredName}\` toggled the All Invite party setting.`,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/Ban.mjs
+++ b/src/mineflayer/commands/party/Ban.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["ban", "block"], // This command will be triggered by either command1 or command2
@@ -27,13 +27,10 @@ export default {
         bot.chat(`/p kick ${player}`);
         setTimeout(() => {
           bot.chat(`/block add ${player}`);
-          bot.webhook.send(
-            {
-              username: bot.config.webhook.name,
-            },
-            {
-              content: `\`${player}\` was banned from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-            },
+          bot.utils.webhookLogger.addMessage(
+            `\`${player}\` was banned from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+            WebhookMessageType.ActionLog,
+            true,
           );
         }, bot.utils.minMsgDelay);
       }, bot.utils.minMsgDelay);

--- a/src/mineflayer/commands/party/Close.mjs
+++ b/src/mineflayer/commands/party/Close.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["close", "private"], // This command will be triggered by either command1 or command2
@@ -17,13 +17,10 @@ export default {
     bot.chat(`/pc The party was closed by ${sender.preferredName}.`);
     setTimeout(() => {
       bot.chat(`/stream close`);
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `The party was closed by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `The party was closed by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/Disband.mjs
+++ b/src/mineflayer/commands/party/Disband.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["disband"], // This command will be triggered by either command1 or command2
@@ -19,13 +19,10 @@ export default {
     );
     setTimeout(() => {
       bot.chat("/p disband");
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `The party was disbanded by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `The party was disbanded by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, 10000);
   },

--- a/src/mineflayer/commands/party/Kick.mjs
+++ b/src/mineflayer/commands/party/Kick.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["kick", "remove"], // This command will be triggered by either command1 or command2
@@ -21,13 +21,10 @@ export default {
     bot.chat(`/pc ${player} was kicked from the party by ${sender.preferredName}.`);
     setTimeout(() => {
       bot.chat(`/p kick ${player}`);
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `\`${player}\` was kicked from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `\`${player}\` was kicked from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/KickOffline.mjs
+++ b/src/mineflayer/commands/party/KickOffline.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["kickoffline", "kickafk", "ko", "ka"], // This command will be triggered by either command1 or command2
@@ -16,13 +16,10 @@ export default {
     bot.chat(`/pc Offline players were purged by ${sender.preferredName}.`);
     setTimeout(() => {
       bot.chat("/p kickoffline");
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `Offline players were purged (from the party) by \`${sender.preferredName}\`.`,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `Offline players were purged (from the party) by \`${sender.preferredName}\`.`,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/Mute.mjs
+++ b/src/mineflayer/commands/party/Mute.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["mute", "unmute"], // This command will be triggered by either command1 or command2
@@ -16,13 +16,10 @@ export default {
     bot.chat("/p mute");
     setTimeout(() => {
       bot.chat(`/pc Party mute was toggled by ${sender.preferredName}.`);
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `Party mute was toggled by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `Party mute was toggled by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/Promote.mjs
+++ b/src/mineflayer/commands/party/Promote.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["promote", "promo", "prom", "pro"], // This command will be triggered by either command1 or command2
@@ -17,13 +17,10 @@ export default {
     bot.chat(`/pc ${player} was promoted by ${sender.preferredName}`);
     setTimeout(() => {
       bot.chat(`/p promote ${player}`);
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `\`${player}\` was party promoted by \`${sender.preferredName}\``,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `\`${player}\` was party promoted by \`${sender.preferredName}\``,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/Stream.mjs
+++ b/src/mineflayer/commands/party/Stream.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["stream", "public", "open"], // This command will be triggered by either command1 or command2
@@ -33,13 +33,10 @@ export default {
     bot.chat(`/pc Party size was set to ${amount} by ${sender.preferredName}.`);
     setTimeout(() => {
       bot.chat(`/stream open ${amount}`);
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `Party size was set to \`${amount}\` by \`${sender.preferredName}\`.`,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `Party size was set to \`${amount}\` by \`${sender.preferredName}\`.`,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/Transfer.mjs
+++ b/src/mineflayer/commands/party/Transfer.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["transfer"], // This command will be triggered by either command1 or command2
@@ -21,13 +21,10 @@ export default {
     bot.chat(`/pc The party was transferred to ${player} by ${sender.preferredName}.`);
     setTimeout(() => {
       bot.chat(`/p transfer ${args[0]}`);
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `The party was transferred to \`${player}\` by \`${sender.preferredName}\`.`,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `The party was transferred to \`${player}\` by \`${sender.preferredName}\`.`,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, bot.utils.minMsgDelay);
   },

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["unban", "unblock"], // This command will be triggered by either command1 or command2
@@ -22,13 +22,10 @@ export default {
         bot.chat(`/block remove ${player}`);
         setTimeout(() => {
           bot.reply(sender, `Unbanned ${player}.`);
-          bot.webhook.send(
-            {
-              username: bot.config.webhook.name,
-            },
-            {
-              content: `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`.`,
-            },
+          bot.utils.webhookLogger.addMessage(
+            `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`.`,
+            WebhookMessageType.ActionLog,
+            true,
           );
         }, bot.utils.minMsgDelay);
       }, bot.utils.minMsgDelay);

--- a/src/mineflayer/commands/sudo/Drain.mjs
+++ b/src/mineflayer/commands/sudo/Drain.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["drain", "empty"], // This command will be triggered by either command1 or command2
@@ -33,13 +33,10 @@ but for now itll be admin only because this command is very much poisable
         bot.chat("/streamgui settings empty");
       }, bot.utils.minMsgDelay);
 
-      bot.webhook.send(
-        {
-          username: bot.config.webhook.name,
-        },
-        {
-          content: `The party was emptied by \`${sender.preferredName}\` Reason: \`${reason}\``,
-        },
+      bot.utils.webhookLogger.addMessage(
+        `The party was emptied by \`${sender.preferredName}\` Reason: \`${reason}\``,
+        WebhookMessageType.ActionLog,
+        true,
       );
     }, 10000);
   },

--- a/src/mineflayer/events/OnKick.mjs
+++ b/src/mineflayer/events/OnKick.mjs
@@ -1,6 +1,4 @@
-import { Collection } from "discord.js";
-import Utils from "../../utils/Utils.mjs";
-import Webhook from "../../utils/Webhook.mjs";
+import { WebhookMessageType } from "../../utils/Interfaces.mjs";
 
 export default {
   name: "Kick Event",
@@ -10,14 +8,12 @@ export default {
    * @param {import("../Bot.mjs").default} bot
    */
   execute: async function (bot, reason, loggedIn) {
-    bot.utils.log("Kicked from server for reason: " + reason, "Error");
-    bot.webhook.send(
-      {
-        username: bot.config.webhook.name,
-      },
-      {
-        content: "Kicked from server for reason: " + reason.extra[0].text,
-      },
+    const reasonstr = JSON.parse(reason)?.extra?.[0]?.text;
+    bot.utils.log(`Kicked from server ${loggedIn ? "" : "during login "}for reason: ${reasonstr} (${reason})`, "Error");
+    bot.utils.webhookLogger.addMessage(
+      `Kicked from server ${loggedIn ? "" : "during login "}for reason: ${reasonstr}`,
+      WebhookMessageType.ActionLog,
+      true,
     );
   },
 };

--- a/src/mineflayer/events/OnceLogin.mjs
+++ b/src/mineflayer/events/OnceLogin.mjs
@@ -1,7 +1,4 @@
-import { Collection } from "discord.js";
-import Utils from "../../utils/Utils.mjs";
-import Webhook from "../../utils/Webhook.mjs";
-import { Permissions } from "../../utils/Interfaces.mjs";
+import { Permissions, WebhookMessageType } from "../../utils/Interfaces.mjs";
 
 export default {
   name: "Login Event",
@@ -55,14 +52,10 @@ export default {
       });
       bot.utils.log("Bot account permission updated", "Info");
     }
-    bot.webhook = new Webhook(bot.config.webhook.url);
-    bot.webhook.send(
-      {
-        username: bot.config.webhook.name,
-      },
-      {
-        content: "Logged in! `(" + bot.username + ")`",
-      },
+    bot.utils.webhookLogger.addMessage(
+      `Logged in! \`(${bot.username})\``,
+      WebhookMessageType.ActionLog,
+      true,
     );
     // schedule first refresh of usernames from UUID
     if (!bot.config.debug.disableUsernameRefresh) {

--- a/src/utils/Interfaces.mjs
+++ b/src/utils/Interfaces.mjs
@@ -52,8 +52,9 @@ export const WebhookMessageType = Object.freeze({
   PublicMessage: 2,
   GuildMessage: 3,
   PartyMessage: 4,
-  Other: 5,
-  All: 6,
+  Bridge: 5,
+  Other: 6, // anything that isn't any of the above
+  All: 7, // all of the above
 });
 
 export const SenderType = Object.freeze({

--- a/src/utils/Interfaces.mjs
+++ b/src/utils/Interfaces.mjs
@@ -52,9 +52,10 @@ export const WebhookMessageType = Object.freeze({
   PublicMessage: 2,
   GuildMessage: 3,
   PartyMessage: 4,
-  Bridge: 5,
-  Other: 6, // anything that isn't any of the above
-  All: 7, // all of the above
+  ActionLog: 5,
+  Bridge: 6,
+  Other: 7, // anything that isn't any of the above
+  All: 8, // all of the above
 });
 
 export const SenderType = Object.freeze({

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -663,7 +663,9 @@ class Utils {
     this.webhookLogger.webhooks.forEach(async (type, url) => {
       const messages = this.webhookLogger.getMessages(type);
       if (messages.length < 1) return;
-      let toSend = `\`\`\`ansi\n${messages.join("\n")}\`\`\``;
+      let toSend;
+      if (type === WebhookMessageType.ActionLog) toSend = messages.join("\n");
+      else toSend = `\`\`\`ansi\n${messages.join("\n")}\`\`\``;
       try {
         let discWebhook = new WebhookClient({ url: url });
         await discWebhook.send(toSend);


### PR DESCRIPTION
- Merged per-type message queues into a single queue, which each webhook takes the applicable messages from
  - Fixes message order problems
- Improved message classification and related regexes
- Added new `WebhookMessageType.Bridge`, which gets filtered using a bridge blacklist
  - When a webhook has this type, it receives `WebhookMessageType.PartyMessage`, `.PrivateMessage`, `.JoinLeave` and `.Bridge`  (which contains messages that aren't in any other category or blacklisted)
- Added new `WebhookMessageType.ActionLog` to replace the old `bot.webhook` main action log
  - This allows for multiple action log webhooks to be configured and integrates it better with other webhook logic
  - Also allows for cleaner webhook configuration in `Config.mjs`
 
NOTE: Make sure to update the webhooks in `Config.mjs` to match the example config's layout and update existing bridge webhooks from `WebhookMessageType.All` to `WebhookMessageType.Bridge`!