### PR TITLE
Added error handling for `getUsername`

### DIFF
--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -160,11 +160,15 @@ class Utils {
 
   /** Get Minecraft player username from uuid */
   async getUsername(uuid) {
-    let data = await axios.get(
-      `https://sessionserver.mojang.com/session/minecraft/profile/${uuid}`,
-    );
-    if (data.data.errorMessage) return null;
-    return data.data.name;
+    try {
+      let data = await axios.get(
+        `https://sessionserver.mojang.com/session/minecraft/profile/${uuid}`,
+      );
+      if (data.data.errorMessage) return null;
+      return data.data.name;
+    } catch (e) {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
- Added error handling for `getUsername` so the bot doesn't crash when the request fails (idk why only `getUUID` had this previously)