### PR TITLE
Discord/Console message replies improved (and colored), small regex fix

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -2,7 +2,7 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import { utils } from "./src/utils/Utils.mjs";
+import Utils, { utils } from "./src/utils/Utils.mjs";
 import * as config from "./Config.mjs";
 import JSONdb from "simple-json-db";
 import path from "path";
@@ -66,9 +66,10 @@ function dataInput(data) {
   data = data.toString().trim();
   if (data.startsWith("/")) myBot.chat(data);
   else if (data.startsWith(myBot.config.partyCommandPrefix))
-    myBot.onMessage({
-      content: `From [CONSOLE] ${myBot.username}: ${data}`,
-      self: true,
-    });
+    myBot.onMessage(
+      new Utils.CustomMessage(
+        `[35mFrom [31m[CONSOLE] ${myBot.username}[37m: ${data}[0m`,
+      ),
+    );
   else if (data.startsWith("!dc")) return; // Add Discord bot stuff
 }

--- a/src/discord/components/commands/RunCommand.mjs
+++ b/src/discord/components/commands/RunCommand.mjs
@@ -1,5 +1,5 @@
 import { ApplicationCommandOptionType, Client, Message } from "discord.js";
-import { utils } from "../../../utils/Utils.mjs";
+import Utils, { utils } from "../../../utils/Utils.mjs";
 import myBot from "../../../mineflayer/Bot.mjs";
 
 export default {
@@ -28,16 +28,18 @@ export default {
     bot.utils.discordReply.setReply(replyId, interaction);
     let preferredName = bot.utils.getPreferredUsername({
       discord: interaction.user.id,
+      forceHideRank: true,
     });
     if (!preferredName)
       return interaction.editReply(
         "You need to link your account first using `/link` and `!p link` in-game!",
       );
-    myBot.onMessage({
-      content: `From ${preferredName}: ${command}`,
-      self: true,
-      discord: true,
-      discordReplyId: replyId,
-    });
+    myBot.onMessage(
+      new Utils.CustomMessage(
+        `[35mFrom [34m[DISCORD] ${preferredName}[37m: ${command}[0m`,
+        true,
+        replyId,
+      ),
+    );
   },
 };

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -2,6 +2,7 @@ import mineflayer from "mineflayer";
 import * as config from "../../Config.mjs";
 import loadPartyCommands from "./handlers/PartyCommandHandler.mjs";
 import { SenderType } from "../utils/Interfaces.mjs";
+import Utils from "../utils/Utils.mjs";
 
 class Bot {
   constructor() {
@@ -38,7 +39,7 @@ class Bot {
    * @param {String} message
    */
   chat(message) {
-    message = this.utils.replaceColorlessEmotes(message)
+    message = this.utils.replaceColorlessEmotes(message);
     // Check message length limit, if it is too long, only perform a cut off
     // – ideally the caller ensures this property already so that it can be
     // handled more gracefully than sending out a probably incomplete chat
@@ -80,11 +81,25 @@ class Bot {
     if (sender.type === SenderType.Minecraft)
       this.chat(`/r ${this.utils.addRandomString(message)}`);
     else if (sender.type === SenderType.Discord) {
+      // log message reply (like with a hypixel dm reply)
+      this.onMessage(
+        new Utils.CustomMessage(
+          `[35mTo [34m[DISCORD] ${sender.username}[37m: ${message}[0m`,
+          true,
+        ),
+      );
       this.utils.discordReply
         .getReply(sender.discordReplyId)
         .editReply(message);
       this.utils.discordReply.removeReply(sender.discordReplyId);
     } else if (sender.type === SenderType.Console) {
+      // log message reply (like with a hypixel dm reply)
+      this.onMessage(
+        new Utils.CustomMessage(
+          `[35mTo [31m[CONSOLE] ${this.username}[37m: ${message}[0m`,
+          true,
+        ),
+      );
       this.utils.log(message, "Info");
     }
   }

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -97,7 +97,6 @@ class Bot {
       this.onMessage(
         new Utils.CustomMessage(
           `[35mTo [31m[CONSOLE] ${this.username}[37m: ${message}[0m`,
-          true,
         ),
       );
       this.utils.log(message, "Info");

--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -1,5 +1,5 @@
 import Utils from "../../utils/Utils.mjs";
-import { SenderType, Permissions } from "../../utils/Interfaces.mjs";
+import { SenderType } from "../../utils/Interfaces.mjs";
 
 export default {
   name: "MessageEvent",
@@ -23,7 +23,7 @@ export default {
     }
     let msgType = SenderType.Minecraft;
     let discordReplyId;
-    if (bot.config.showMcChat && !message.self) {
+    if (bot.config.showMcChat) {
       console.log(message.toAnsi());
       bot.utils.webhookLogger.addMessage(
         message.toAnsi(undefined, bot.utils.discordAnsiCodes),
@@ -36,19 +36,14 @@ export default {
         bot.chat(`/p accept ${partyInvite}`);
       }, bot.utils.minMsgDelay);
     }
-    if (message.self == true) {
+    if (message.self === true) {
       msgType = SenderType.Console;
-      if (message.discord) {
+      if (message.isDiscord) {
         msgType = SenderType.Discord;
         discordReplyId = message.discordReplyId;
       }
-      message = message.content;
-      bot.utils.webhookLogger.addMessage(
-        message,
-        bot.utils.classifyMessage(message.toString()),
-      );
     }
-    const command = message.toString().split(": ").slice(1).join(": ")
+    const command = message.toString().split(": ").slice(1).join(": ");
     const args = command.split(" ");
     let commandFound;
     if (RegExp(/^From /g).test(message.toString())) {
@@ -103,14 +98,16 @@ export default {
       const commandName = args[1];
       const commandArgs = args.slice(2);
       let sender = Utils.extractUsername(message.toString());
-      // Get Hypixel rank from the message
-      const rank = Utils.extractHypixelRank(message.toString());
-      // Update the sender account's hypixel rank if necessary (will fail safely if user is not in db)
-      if (bot.utils.getHypixelRank({ name: sender }) !== rank)
-        bot.utils.setHypixelRank({
-          name: sender,
-          hypixelRank: rank,
-        });
+      if (msgType === SenderType.Minecraft) {
+        // Get Hypixel rank from the message
+        const rank = Utils.extractHypixelRank(message.toString());
+        // Update the sender account's hypixel rank if necessary (will fail safely if user is not in db)
+        if (bot.utils.getHypixelRank({ name: sender }) !== rank)
+          bot.utils.setHypixelRank({
+            name: sender,
+            hypixelRank: rank,
+          });
+      }
       sender = {
         username: sender,
         preferredName: bot.utils.getPreferredUsername({ name: sender }),

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -890,7 +890,7 @@ const bridgeBlacklistRegex = Object.freeze([
   /^You tipped \d+ players? in \d+ (different )?games?!$/,
   /^-+$/,
   /^ *$/,
-  /^[WATCHDOG ANNOUNCEMENT]$/,
+  /^\[WATCHDOG ANNOUNCEMENT\]$/,
   /^Watchdog has banned [\d,]+ players in the last 7 days\.$/,
   /^Staff have banned an additional [\d,]+ in the last 7 days\.$/,
   /^Blacklisted modifications are a bannable offense!$/,

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -954,6 +954,24 @@ const hypixelEmotes = {
   ":puffer:": "<('O')>",
 };
 
+// class to replace (and emulate parts of) mineflayer's ChatMessage for custom console/discord messages or commands
+class CustomMessage {
+  constructor(message, isDiscord = false, discordReplyId = null) {
+    this.self = true;
+    this.ansiMessage = message;
+    this.isDiscord = isDiscord;
+    this.discordReplyId = discordReplyId;
+  }
+
+  toString() {
+    return this.ansiMessage.replace(/\[\d+m/g, "");
+  }
+
+  toAnsi() {
+    return this.ansiMessage;
+  }
+}
+
 export default {
   extractUsername: function (message) {
     return message.match(/^(Party >|From)( \[.+\])? (\w+): .+$/)?.[3];
@@ -982,6 +1000,8 @@ export default {
   capitalizeFirstLetter: function (string) {
     return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
   },
+
+  CustomMessage: CustomMessage,
 };
 
 let utils = new Utils(


### PR DESCRIPTION
- Discord and Console commands are now sent to `MessageEvent` as an instance of the new `CustomMessage` class
  - The `CustomMessage` class serves as a replacement for mineflayer's `ChatMessage` for non-minecraft messages, emulating some of its needed features (`toString()` and `toAnsi()`)
    - This allows for more generalised message handling, independent of the message origin (minecraft/discord/console)
    - Makes it easier to support discord ansi codes in these replies while also accessing the raw message
- Both discord and console messages now have color in discord logs
- Replies to commands sent from console or discord are now logged in the bot's webhook logs as hypixel-style reply messages
- Fixed a problem with the watchdog announcement bridge blacklist regex (forgot to escape `[]` lol)