### PR TITLE
Updated user management commands

### DIFF
--- a/src/mineflayer/commands/admin/AddUser.mjs
+++ b/src/mineflayer/commands/admin/AddUser.mjs
@@ -5,7 +5,7 @@ export default {
   name: ["adduser", "user"],
   ignore: false,
   description: "Adds users to the permission list or changes their permission",
-  permission: Permissions.Admin,
+  permission: Permissions.Staff,
   // Eventually a sudo command
   /**
    *

--- a/src/mineflayer/commands/admin/AddUser.mjs
+++ b/src/mineflayer/commands/admin/AddUser.mjs
@@ -32,6 +32,13 @@ export default {
       if (bot.utils.getUserObject({ name: user }))
         return bot.reply(sender, `${data.name} is already in the database!`);
       const mainUser = args[1];
+      if (
+        bot.utils.isHigherRanked(sender.username, mainUser)
+      )
+        return bot.reply(
+          sender,
+          `Your permission rank is too low to perform this operation.`,
+        );
       bot.utils.addUser({
         name: data.name,
         uuid: data.uuid,
@@ -45,9 +52,16 @@ export default {
         permissionRank = Permissions[Utils.capitalizeFirstLetter(args[1])];
       else permissionRank = parseInt(args[1]);
       // Check if permission is valid
-      if (!Object.values(Permissions).includes(permissionRank)) {
+      if (!Object.values(Permissions).includes(permissionRank))
         return bot.reply(sender, `Invalid permission rank: ${args[1]}.`);
-      }
+      if (
+        permissionRank >=
+        bot.utils.getPermissionsByUser({ name: sender.username })
+      )
+        return bot.reply(
+          sender,
+          `Your permission rank is too low to perform this operation.`,
+        );
       if (bot.utils.getUserObject({ name: data.name })) {
         // Update permission rank if user exists
         bot.utils.setPermissionRank({

--- a/src/mineflayer/commands/admin/RemoveUser.mjs
+++ b/src/mineflayer/commands/admin/RemoveUser.mjs
@@ -21,6 +21,11 @@ export default {
       );
     if (!bot.utils.getUserObject({ name: user }))
       return bot.reply(sender, `User ${user} not found in database!`);
+    if (!bot.utils.isHigherRanked(sender.username, user))
+      return bot.reply(
+        sender,
+        `Your permission rank is too low to perform this operation.`,
+      );
     bot.utils.removeUser({ name: user, onlyThis: only });
     if (only)
       return bot.reply(sender, `Removed account ${user}, but kept other alts.`);

--- a/src/mineflayer/commands/admin/RemoveUser.mjs
+++ b/src/mineflayer/commands/admin/RemoveUser.mjs
@@ -4,7 +4,7 @@ export default {
   name: ["removeuser"],
   ignore: false,
   description: "Removes a user from the permission list",
-  permission: Permissions.Admin,
+  permission: Permissions.Staff,
   /**
    *
    * @param {import("../../Bot.mjs").default} bot


### PR DESCRIPTION
- `!p adduser` and `!p removeuser` now require a strictly higher permission rank than the person affected by the command for it to execute
- Lowered the permission requirement of those commands to `Permissions.Staff` so staff can add splashers (used to be `.Admin`)