### PR TITLE
Fix tiny but crucial mistake in `!p adduser` code

### DIFF
--- a/src/mineflayer/commands/admin/AddUser.mjs
+++ b/src/mineflayer/commands/admin/AddUser.mjs
@@ -33,7 +33,7 @@ export default {
         return bot.reply(sender, `${data.name} is already in the database!`);
       const mainUser = args[1];
       if (
-        bot.utils.isHigherRanked(sender.username, mainUser)
+        !bot.utils.isHigherRanked(sender.username, mainUser)
       )
         return bot.reply(
           sender,


### PR DESCRIPTION
- Fixed `!p adduser` permission check for adding alts missing a `!` (essentially users that were in the db but didn't have perms could add alts and users with perms couldn't..)