### PR TITLE
Modify `getPermissionRank` to return `-1` instead of `null` when no perms

### DIFF
--- a/src/mineflayer/commands/misc/Test.mjs
+++ b/src/mineflayer/commands/misc/Test.mjs
@@ -24,7 +24,7 @@ export default {
       permissionRank = bot.utils.getPermissionsByUser({
         name: sender.username,
       });
-    if (!permissionRank)
+    if (permissionRank < 0)
       return;
     const permission = Object.keys(Permissions).find(
       (perm) => Permissions[perm] === permissionRank,

--- a/src/mineflayer/events/OnceLogin.mjs
+++ b/src/mineflayer/events/OnceLogin.mjs
@@ -38,7 +38,7 @@ export default {
     const permissionRank = bot.utils.getPermissionsByUser({
       name: bot.username,
     });
-    if (!permissionRank) {
+    if (permissionRank < 0) {
       bot.utils.addUser({
         name: bot.username,
         uuid: await bot.utils.getUUID(bot.username),

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -227,10 +227,10 @@ class Utils {
    * @returns {Object|null}
    */
   getPermissionsByUser(options = {}) {
-    if (!options || (!options.uuid && !options.name)) return null;
+    if (!options || (!options.uuid && !options.name)) return -1;
 
     let userObj = this.getUserObject(options);
-    if (!userObj) return null;
+    if (!userObj) return -1;
     return userObj.permissionRank;
   }
 
@@ -654,8 +654,7 @@ class Utils {
       ?.clickEvent?.value?.slice(14);
     if (
       inviteIGN &&
-      (this.getPermissionsByUser({ name: inviteIGN }) ??
-        Permissions.ExSplasher) >= Permissions.Splasher
+      this.getPermissionsByUser({ name: inviteIGN }) >= Permissions.Splasher
     ) {
       return inviteIGN;
     } else {


### PR DESCRIPTION
- Fix permission exploit by having `getPermissionRank` return `-1` instead of `null` when the user isn't in the db