### PR TITLE
Fix incorrect `await` syntax in some command logic, differentiate between invalid and failed request for `getUUID` and `getUsername`

### DIFF
--- a/src/mineflayer/commands/party/Invite.mjs
+++ b/src/mineflayer/commands/party/Invite.mjs
@@ -15,9 +15,11 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = (await bot.utils.getUUID(args[0], true))?.name;
-      if (!player)
+      player = await bot.utils.getUUID(args[0], true);
+      if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
+      // proceed with raw provided name if api request failed for any reason (uncertain validity)
+      player = player ? player.name : args[0];
     } else player = sender.username;
     bot.chat(`/p invite ${player}`);
     setTimeout(() => {

--- a/src/mineflayer/commands/party/Invite.mjs
+++ b/src/mineflayer/commands/party/Invite.mjs
@@ -15,7 +15,7 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true)?.name;
+      player = (await bot.utils.getUUID(args[0], true))?.name;
       if (!player)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
     } else player = sender.username;

--- a/src/mineflayer/commands/party/Kick.mjs
+++ b/src/mineflayer/commands/party/Kick.mjs
@@ -19,9 +19,11 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = (await bot.utils.getUUID(args[0], true))?.name;
-      if (!player)
+      player = await bot.utils.getUUID(args[0], true);
+      if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
+      // proceed with raw provided name if api request failed for any reason (uncertain validity)
+      player = player ? player.name : args[0];
     } else
       return bot.reply(
         sender,

--- a/src/mineflayer/commands/party/Kick.mjs
+++ b/src/mineflayer/commands/party/Kick.mjs
@@ -19,7 +19,7 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true)?.name;
+      player = (await bot.utils.getUUID(args[0], true))?.name;
       if (!player)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
     } else

--- a/src/mineflayer/commands/party/Promote.mjs
+++ b/src/mineflayer/commands/party/Promote.mjs
@@ -19,7 +19,7 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true)?.name;
+      player = (await bot.utils.getUUID(args[0], true))?.name;
       if (!player)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
     } else player = sender.username;

--- a/src/mineflayer/commands/party/Promote.mjs
+++ b/src/mineflayer/commands/party/Promote.mjs
@@ -19,9 +19,11 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = (await bot.utils.getUUID(args[0], true))?.name;
-      if (!player)
+      player = await bot.utils.getUUID(args[0], true);
+      if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
+      // proceed with raw provided name if api request failed for any reason (uncertain validity)
+      player = player ? player.name : args[0];
     } else player = sender.username;
     bot.chat(`/pc ${player} was promoted by ${sender.preferredName}`);
     setTimeout(() => {

--- a/src/mineflayer/commands/party/Transfer.mjs
+++ b/src/mineflayer/commands/party/Transfer.mjs
@@ -19,9 +19,11 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = (await bot.utils.getUUID(args[0], true))?.name;
-      if (!player)
+      player = await bot.utils.getUUID(args[0], true);
+      if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
+      // proceed with raw provided name if api request failed for any reason (uncertain validity)
+      player = player ? player.name : args[0];
     } else
       return bot.reply(
         sender,

--- a/src/mineflayer/commands/party/Transfer.mjs
+++ b/src/mineflayer/commands/party/Transfer.mjs
@@ -19,7 +19,7 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true)?.name;
+      player = (await bot.utils.getUUID(args[0], true))?.name;
       if (!player)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
     } else

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -19,9 +19,11 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = (await bot.utils.getUUID(args[0], true))?.name;
-      if (!player)
+      player = await bot.utils.getUUID(args[0], true);
+      if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
+      // proceed with raw provided name if api request failed for any reason (uncertain validity)
+      player = player ? player.name : args[0];
     } else
       return bot.reply(
         sender,

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -19,7 +19,7 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true)?.name;
+      player = (await bot.utils.getUUID(args[0], true))?.name;
       if (!player)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
     } else

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -29,9 +29,11 @@ export default {
       message = `${sender.preferredName} is splashing in Hub ${hubNumber}${hubID ? ` (${hubID})` : ""} soon!`;
     } else if (/^\/p join \w{3,16}/.test(args.join(" "))) {
       // validate username for /p join
-      const pjoinUsername = (await bot.utils.getUUID(args[2], true))?.name;
-      if (!pjoinUsername)
+      let pjoinUsername = await bot.utils.getUUID(args[2], true);
+      if (pjoinUsername === false)
         return bot.reply(sender, "Username not found.", VerbosityLevel.Reduced);
+      // proceed with raw provided name if api request failed for any reason (uncertain validity)
+      pjoinUsername = pjoinUsername ? pjoinUsername.name : args[2];
       message = `${sender.preferredName} is splashing soon! Run '/p join ${pjoinUsername}' to get warped!`;
     } else if (args[0] === "switch" && !isNaN(args[1])) {
       // announce hub has shifted

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -29,7 +29,7 @@ export default {
       message = `${sender.preferredName} is splashing in Hub ${hubNumber}${hubID ? ` (${hubID})` : ""} soon!`;
     } else if (/^\/p join \w{3,16}/.test(args.join(" "))) {
       // validate username for /p join
-      const pjoinUsername = await bot.utils.getUUID(args[2], true)?.name;
+      const pjoinUsername = (await bot.utils.getUUID(args[2], true))?.name;
       if (!pjoinUsername)
         return bot.reply(sender, "Username not found.", VerbosityLevel.Reduced);
       message = `${sender.preferredName} is splashing soon! Run '/p join ${pjoinUsername}' to get warped!`;

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -172,13 +172,11 @@ class Utils {
       let data = await axios.get(
         `https://sessionserver.mojang.com/session/minecraft/profile/${uuid}`,
       );
-      // provided UUID is invalid (correct length, invalid)
-      if (data.status === 204) return false;
       return data.data.name;
     } catch (e) {
       switch (e?.status) {
         case 400:
-          // provided UUID is invalid (incorrect length)
+          // provided UUID is invalid
           return false;
         case 404:
           // provided UUID is invalid (contains slash)


### PR DESCRIPTION
- Fixed incorrect `await` syntax in commands that use `getUUID` for username validation (attempted to access property on `Promise` before resolving it)
- `getUUID` and `getUsername` now return `false` when the name/uuid is invalid according to the api, `null` if the request failed for another reason
  - both of these values are falsy, which means they are both caught by an `if (!data) {}`
  - commands that validate usernames will now proceed with the raw, unvalidated input if the api request failed (meaning that commands won't break if api is unreachable)