### PR TITLE
`usernameExists` and `delay` util functions, `!p cmd` verbosity setting bypass, new `!p setguide` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,6 @@ than directly going to their underlying implementations:
 
 - If you want to issue multiple commands to Hypixel via Minecraft chat back to
   back:
-  - TODO: Note: This is currently not yet implemented and live/ready to use!
   ```js
   await bot.utils.delay(bot.utils.minMsgDelay);
   bot.chat(`/someCommand`);

--- a/src/discord/components/commands/Guide.mjs
+++ b/src/discord/components/commands/Guide.mjs
@@ -36,7 +36,7 @@ export default {
     bot.utils.setMonthGuide({
       link: link,
       overwrite: true,
-      date: interaction.options.getString("date"),
+      time: interaction.options.getString("date"),
     });
     await interaction.reply({
       content: "Guide link has been set!",

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -162,9 +162,7 @@ class Bot {
   }
 
   async onSpawn() {
-    await new Promise((resolve) =>
-      setTimeout(resolve, this.utils.minMsgDelay * 3),
-    );
+    await this.utils.delay(this.utils.minMsgDelay * 3);
     this.bot.chat("/locraw");
   }
 }

--- a/src/mineflayer/commands/admin/Cmd.mjs
+++ b/src/mineflayer/commands/admin/Cmd.mjs
@@ -14,12 +14,11 @@ export default {
    */
   execute: async function (bot, sender, args) {
     bot.chat("/" + args.join(" "));
-    setTimeout(() => {
-      bot.reply(
-        sender,
-        `Executed command: /${args.join(" ")}`,
-        VerbosityLevel.Reduced,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.reply(
+      sender,
+      `Executed command: /${args.join(" ")}`,
+      VerbosityLevel.Reduced,
+    );
   },
 };

--- a/src/mineflayer/commands/admin/Cmd.mjs
+++ b/src/mineflayer/commands/admin/Cmd.mjs
@@ -13,7 +13,8 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    bot.chat("/" + args.join(" "));
+    // bypass verbosity setting for `!p cmd`
+    bot.chat("/" + args.join(" "), VerbosityLevel.Off);
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.reply(
       sender,

--- a/src/mineflayer/commands/admin/Limbo.mjs
+++ b/src/mineflayer/commands/admin/Limbo.mjs
@@ -14,11 +14,9 @@ export default {
    */
   execute: async function (bot, sender, args) {
     bot.chat("/lobby");
-    setTimeout(() => {
-      bot.chat("/limbo");
-      setTimeout(() => {
-        bot.reply(sender, `Limboed!`, VerbosityLevel.Reduced);
-      }, bot.utils.minMsgDelay);
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat("/limbo");
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.reply(sender, `Limboed!`, VerbosityLevel.Reduced);
   },
 };

--- a/src/mineflayer/commands/admin/SetGuide.mjs
+++ b/src/mineflayer/commands/admin/SetGuide.mjs
@@ -1,0 +1,44 @@
+import {
+  VerbosityLevel,
+  WebhookMessageType,
+} from "../../../utils/Interfaces.mjs";
+
+export default {
+  name: ["setguide"],
+  description:
+    "Sets/overwrites the current or a specific month's bingo guide link",
+  usage: "!p setguide <link> [MM/YYYY]",
+  permission: Permissions.Admin,
+
+  /**
+   *
+   * @param {import("../../Bot.mjs").default} bot
+   * @param {String} sender
+   * @param {Array<String>} args
+   */
+  execute: async function (bot, sender, args) {
+    if (!args[0] || (args[1] && !/^\d{2}\/\d{4}$/.test(args[1])))
+      return bot.reply(
+        sender,
+        `Invalid usage! Use: ${this.usage}`,
+        VerbosityLevel.Reduced,
+      );
+    if (!/^https:\/\/hypixel\.net\/threads\/bingo/.test(args[0]))
+      return bot.reply(
+        sender,
+        "Invalid guide link! Link must adhere to the following format: 'https://hypixel.net/threads/bingo...'",
+        VerbosityLevel.Reduced,
+      );
+    bot.utils.setMonthGuide({
+      link: args[0],
+      overwrite: true,
+      time: args[1],
+    });
+    bot.reply(sender, "Guide link has been set.", VerbosityLevel.Reduced);
+    bot.utils.webhookLogger.addMessage(
+      `The guide link for ${args[1] ? `\`${args[1]}\`` : "this month"} has been set to \`${args[0]}\` by \`${sender.preferredName}\`.`,
+      WebhookMessageType.ActionLog,
+      true,
+    );
+  },
+};

--- a/src/mineflayer/commands/misc/Help.mjs
+++ b/src/mineflayer/commands/misc/Help.mjs
@@ -22,7 +22,6 @@ export default {
       let message = `Available commands: ${bot.partyCommands.map((value, key) => key[0]).join(", ")}`;
       // split message as many times as necessary if it's too long
       if (message.length > 252) {
-        let i = 1;
         while (message.length) {
           let splitIndex =
             message.length <= 252
@@ -30,12 +29,9 @@ export default {
               : message.slice(0, 252).lastIndexOf(" ");
           if (splitIndex === -1) splitIndex = 252;
           const toSend = message.slice(0, splitIndex);
-          setTimeout(
-            () => bot.reply(sender, toSend, VerbosityLevel.Minimal),
-            i * bot.utils.minMsgDelay,
-          );
+          bot.reply(sender, toSend, VerbosityLevel.Minimal);
+          await bot.utils.delay(bot.utils.minMsgDelay);
           message = message.slice(splitIndex + 1);
-          i++;
         }
       } else bot.reply(sender, message, VerbosityLevel.Minimal);
     } else {

--- a/src/mineflayer/commands/misc/PreferredName.mjs
+++ b/src/mineflayer/commands/misc/PreferredName.mjs
@@ -33,15 +33,8 @@ export default {
       if (message.length > 252) {
         const splitIndex = message.slice(0, 253).lastIndexOf(" ");
         bot.reply(sender, message.slice(0, splitIndex), VerbosityLevel.Minimal);
-        setTimeout(
-          () =>
-            bot.reply(
-              sender,
-              message.slice(splitIndex),
-              VerbosityLevel.Minimal,
-            ),
-          bot.utils.minMsgDelay,
-        );
+        await bot.utils.delay(bot.utils.minMsgDelay);
+        bot.reply(sender, message.slice(splitIndex), VerbosityLevel.Minimal);
         return;
       }
       return bot.reply(sender, message, VerbosityLevel.Minimal);

--- a/src/mineflayer/commands/party/AllInvite.mjs
+++ b/src/mineflayer/commands/party/AllInvite.mjs
@@ -14,13 +14,12 @@ export default {
    */
   execute: async function (bot, sender, args) {
     bot.chat(`/pc ${sender.preferredName} toggled the All Invite setting.`);
-    setTimeout(() => {
-      bot.chat("/p settings allinvite");
-      bot.utils.webhookLogger.addMessage(
-        `\`${sender.preferredName}\` toggled the All Invite party setting.`,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat("/p settings allinvite");
+    bot.utils.webhookLogger.addMessage(
+      `\`${sender.preferredName}\` toggled the All Invite party setting.`,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Ban.mjs
+++ b/src/mineflayer/commands/party/Ban.mjs
@@ -31,19 +31,16 @@ export default {
     bot.chat(
       `/pc ${player} was removed from the party and blocked from rejoining by ${sender.preferredName}.`,
     );
-    setTimeout(() => {
-      bot.chat(`/lobby`);
-      setTimeout(() => {
-        bot.chat(`/p kick ${player}`);
-        setTimeout(() => {
-          bot.chat(`/block add ${player}`);
-          bot.utils.webhookLogger.addMessage(
-            `\`${player}\` was banned from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-            WebhookMessageType.ActionLog,
-            true,
-          );
-        }, bot.utils.minMsgDelay);
-      }, bot.utils.minMsgDelay);
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/lobby`);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/p kick ${player}`);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/block add ${player}`);
+    bot.utils.webhookLogger.addMessage(
+      `\`${player}\` was banned from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Close.mjs
+++ b/src/mineflayer/commands/party/Close.mjs
@@ -15,13 +15,12 @@ export default {
   execute: async function (bot, sender, args) {
     let reason = args.slice(0).join(" ") || "No reason given.";
     bot.chat(`/pc The party was closed by ${sender.preferredName}.`);
-    setTimeout(() => {
-      bot.chat(`/stream close`);
-      bot.utils.webhookLogger.addMessage(
-        `The party was closed by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/stream close`);
+    bot.utils.webhookLogger.addMessage(
+      `The party was closed by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Invite.mjs
+++ b/src/mineflayer/commands/party/Invite.mjs
@@ -20,8 +20,7 @@ export default {
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
     } else player = sender.username;
     bot.chat(`/p invite ${player}`);
-    setTimeout(() => {
-      bot.chat(`/pc ${sender.preferredName} invited ${player} to the party.`);
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/pc ${sender.preferredName} invited ${player} to the party.`);
   },
 };

--- a/src/mineflayer/commands/party/Invite.mjs
+++ b/src/mineflayer/commands/party/Invite.mjs
@@ -15,11 +15,9 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true);
+      player = await bot.utils.usernameExists(args[0]);
       if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-      // proceed with raw provided name if api request failed for any reason (uncertain validity)
-      player = player ? player.name : args[0];
     } else player = sender.username;
     bot.chat(`/p invite ${player}`);
     setTimeout(() => {

--- a/src/mineflayer/commands/party/Kick.mjs
+++ b/src/mineflayer/commands/party/Kick.mjs
@@ -35,13 +35,12 @@ export default {
     bot.chat(
       `/pc ${player} was kicked from the party by ${sender.preferredName}.`,
     );
-    setTimeout(() => {
-      bot.chat(`/p kick ${player}`);
-      bot.utils.webhookLogger.addMessage(
-        `\`${player}\` was kicked from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/p kick ${player}`);
+    bot.utils.webhookLogger.addMessage(
+      `\`${player}\` was kicked from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Kick.mjs
+++ b/src/mineflayer/commands/party/Kick.mjs
@@ -19,11 +19,9 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true);
+      player = await bot.utils.usernameExists(args[0]);
       if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-      // proceed with raw provided name if api request failed for any reason (uncertain validity)
-      player = player ? player.name : args[0];
     } else
       return bot.reply(
         sender,

--- a/src/mineflayer/commands/party/KickOffline.mjs
+++ b/src/mineflayer/commands/party/KickOffline.mjs
@@ -13,13 +13,12 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    setTimeout(() => {
-      bot.chat("/p kickoffline");
-      bot.utils.webhookLogger.addMessage(
-        `Offline players were purged from the party by \`${sender.preferredName}\`.`,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat("/p kickoffline");
+    bot.utils.webhookLogger.addMessage(
+      `Offline players were purged from the party by \`${sender.preferredName}\`.`,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Mute.mjs
+++ b/src/mineflayer/commands/party/Mute.mjs
@@ -15,13 +15,12 @@ export default {
   execute: async function (bot, sender, args) {
     let reason = args.join(" ") || "No reason given.";
     bot.chat("/p mute");
-    setTimeout(() => {
-      bot.chat(`/pc Party mute was toggled by ${sender.preferredName}.`);
-      bot.utils.webhookLogger.addMessage(
-        `Party mute was toggled by \`${sender.preferredName}\`. Reason: \`${reason}\``,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/pc Party mute was toggled by ${sender.preferredName}.`);
+    bot.utils.webhookLogger.addMessage(
+      `Party mute was toggled by \`${sender.preferredName}\`. Reason: \`${reason}\``,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Open.mjs
+++ b/src/mineflayer/commands/party/Open.mjs
@@ -31,13 +31,12 @@ export default {
     );
 
     bot.chat(`/pc Party size was set to ${amount} by ${sender.preferredName}.`);
-    setTimeout(() => {
-      bot.chat(`/stream open ${amount}`);
-      bot.utils.webhookLogger.addMessage(
-        `Party size was set to \`${amount}\` by \`${sender.preferredName}\`.`,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/stream open ${amount}`);
+    bot.utils.webhookLogger.addMessage(
+      `Party size was set to \`${amount}\` by \`${sender.preferredName}\`.`,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Promote.mjs
+++ b/src/mineflayer/commands/party/Promote.mjs
@@ -24,13 +24,12 @@ export default {
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
     } else player = sender.username;
     bot.chat(`/pc ${player} was promoted by ${sender.preferredName}`);
-    setTimeout(() => {
-      bot.chat(`/p promote ${player}`);
-      bot.utils.webhookLogger.addMessage(
-        `\`${player}\` was party promoted by \`${sender.preferredName}\``,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/p promote ${player}`);
+    bot.utils.webhookLogger.addMessage(
+      `\`${player}\` was party promoted by \`${sender.preferredName}\``,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Promote.mjs
+++ b/src/mineflayer/commands/party/Promote.mjs
@@ -19,11 +19,9 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true);
+      player = await bot.utils.usernameExists(args[0]);
       if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-      // proceed with raw provided name if api request failed for any reason (uncertain validity)
-      player = player ? player.name : args[0];
     } else player = sender.username;
     bot.chat(`/pc ${player} was promoted by ${sender.preferredName}`);
     setTimeout(() => {

--- a/src/mineflayer/commands/party/Rule.mjs
+++ b/src/mineflayer/commands/party/Rule.mjs
@@ -34,8 +34,7 @@ export default {
     // TODO: update rules (both data & usage system/mechanism)
     // bot.chat("/pc --- Bingo Brewers Rules (Outdated)---");
     bot.chat("/pc --- Bingo Brewers Rules ---", VerbosityLevel.Minimal);
-    setTimeout(() => {
-      bot.chat(`/pc Rule ${ruleNum}: ${rule}`, VerbosityLevel.Minimal);
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/pc Rule ${ruleNum}: ${rule}`, VerbosityLevel.Minimal);
   },
 };

--- a/src/mineflayer/commands/party/Transfer.mjs
+++ b/src/mineflayer/commands/party/Transfer.mjs
@@ -19,11 +19,9 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true);
+      player = await bot.utils.usernameExists(args[0]);
       if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-      // proceed with raw provided name if api request failed for any reason (uncertain validity)
-      player = player ? player.name : args[0];
       /* TODO: a check could (potentially) be added here if the transferred-to
       player has the MVP++ rank (but bypassable by `confirm`ing the command)… */
     } else

--- a/src/mineflayer/commands/party/Transfer.mjs
+++ b/src/mineflayer/commands/party/Transfer.mjs
@@ -33,13 +33,12 @@ export default {
     bot.chat(
       `/pc The party was transferred to ${player} by ${sender.preferredName}.`,
     );
-    setTimeout(() => {
-      bot.chat(`/p transfer ${args[0]}`);
-      bot.utils.webhookLogger.addMessage(
-        `The party was transferred to \`${player}\` by \`${sender.preferredName}\`.`,
-        WebhookMessageType.ActionLog,
-        true,
-      );
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/p transfer ${args[0]}`);
+    bot.utils.webhookLogger.addMessage(
+      `The party was transferred to \`${player}\` by \`${sender.preferredName}\`.`,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -29,19 +29,16 @@ export default {
         VerbosityLevel.Reduced,
       );
     bot.reply(sender, `Trying to unban ${player}...`, VerbosityLevel.Reduced);
-    setTimeout(() => {
-      bot.chat(`/lobby`);
-      setTimeout(() => {
-        bot.chat(`/block remove ${player}`);
-        setTimeout(() => {
-          bot.reply(sender, `Unbanned ${player}.`, VerbosityLevel.Reduced);
-          bot.utils.webhookLogger.addMessage(
-            `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`.`,
-            WebhookMessageType.ActionLog,
-            true,
-          );
-        }, bot.utils.minMsgDelay);
-      }, bot.utils.minMsgDelay);
-    }, bot.utils.minMsgDelay);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/lobby`);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/block remove ${player}`);
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.reply(sender, `Unbanned ${player}.`, VerbosityLevel.Reduced);
+    bot.utils.webhookLogger.addMessage(
+      `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`.`,
+      WebhookMessageType.ActionLog,
+      true,
+    );
   },
 };

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -19,11 +19,9 @@ export default {
   execute: async function (bot, sender, args) {
     let player;
     if (args[0]) {
-      player = await bot.utils.getUUID(args[0], true);
+      player = await bot.utils.usernameExists(args[0]);
       if (player === false)
         return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-      // proceed with raw provided name if api request failed for any reason (uncertain validity)
-      player = player ? player.name : args[0];
     } else
       return bot.reply(
         sender,

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -29,11 +29,9 @@ export default {
       message = `${sender.preferredName} is splashing in Hub ${hubNumber}${hubID ? ` (${hubID})` : ""} soon!`;
     } else if (/^\/p join \w{3,16}/.test(args.join(" "))) {
       // validate username for /p join
-      let pjoinUsername = await bot.utils.getUUID(args[2], true);
+      let pjoinUsername = await bot.utils.usernameExists(args[2]);
       if (pjoinUsername === false)
         return bot.reply(sender, "Username not found.", VerbosityLevel.Reduced);
-      // proceed with raw provided name if api request failed for any reason (uncertain validity)
-      pjoinUsername = pjoinUsername ? pjoinUsername.name : args[2];
       message = `${sender.preferredName} is splashing soon! Run '/p join ${pjoinUsername}' to get warped!`;
     } else if (args[0] === "switch" && !isNaN(args[1])) {
       // announce hub has shifted

--- a/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
@@ -30,8 +30,7 @@ export default {
       .getCommandByAlias(bot, "repeat")
       .execute(bot, sender, `4 4 ${args.join(" ")}`.split(" "));
 
-    setTimeout(() => {
-      bot.utils.getCommandByAlias(bot, "say").execute(bot, sender, args);
-    }, 12_000 + 20_000);
+    await bot.utils.delay(12_000 + 20_000);
+    bot.utils.getCommandByAlias(bot, "say").execute(bot, sender, args);
   },
 };

--- a/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
@@ -38,14 +38,10 @@ export default {
       );
 
     for (let i = 0; i < repetitions; i++) {
-      setTimeout(
-        () => {
-          bot.utils
-            .getCommandByAlias(bot, "say")
-            .execute(bot, sender, args.slice(startIndex));
-        },
-        i * (duration * 1000),
-      );
+      bot.utils
+        .getCommandByAlias(bot, "say")
+        .execute(bot, sender, args.slice(startIndex));
+      await bot.utils.delay(duration * 1000);
     }
   },
 };

--- a/src/mineflayer/events/MessageEvent.mjs
+++ b/src/mineflayer/events/MessageEvent.mjs
@@ -32,9 +32,8 @@ export default {
     }
     const partyInvite = bot.utils.findValidPartyInvite(message);
     if (partyInvite && !bot.utils.getCommandByAlias(bot, "invite").disabled) {
-      setTimeout(() => {
-        bot.chat(`/p accept ${partyInvite}`);
-      }, bot.utils.minMsgDelay);
+      await bot.utils.delay(bot.utils.minMsgDelay);
+      bot.chat(`/p accept ${partyInvite}`);
     }
     if (message.self === true) {
       msgType = SenderType.Console;
@@ -110,7 +109,11 @@ export default {
           bot.utils.getPermissionsByUser({ name: sender.username })
       ) {
         if (command.disabled)
-          return bot.reply(sender, "This command is currently disabled!", VerbosityLevel.Minimal);
+          return bot.reply(
+            sender,
+            "This command is currently disabled!",
+            VerbosityLevel.Minimal,
+          );
         command.execute(bot, sender, commandArgs);
       } else if (bot.utils.getUserObject({ name: sender.username }))
         // don't reply if user is not in the db

--- a/src/mineflayer/events/OnceLogin.mjs
+++ b/src/mineflayer/events/OnceLogin.mjs
@@ -26,14 +26,13 @@ export default {
         uuid: "YOUR UUID",
         permissionRank: Permissions.Owner,
       });
-      setTimeout(() => {
-        bot.utils.log("Added Bot account to database", "Info");
-        bot.utils.log(
-          "Please turn off bot and add your own account to the database",
-          "Error",
-        );
-        process.exit(1);
-      }, 1000);
+      bot.utils.log("Added Bot account to database", "Info");
+      bot.utils.log(
+        "Please turn off bot and add your own account to the database",
+        "Error",
+      );
+      await bot.utils.delay(1000);
+      process.exit(1);
     }
     const permissionRank = bot.utils.getPermissionsByUser({
       name: bot.username,

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -53,6 +53,15 @@ class Utils {
     logger[type.toLowerCase()](message);
   }
 
+  /**
+   *
+   * @param {Number} ms
+   * @returns {Promise<void>} resolves after the given delay
+   */
+  delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
   async getRulesList() {
     if (this.rulesList.length === 0)
       this.rulesList = await import(
@@ -398,7 +407,7 @@ class Utils {
         else acc.name = username;
         userObj.accounts[userObj.accounts.indexOf(acc)];
         // this delay isn't necessary for any rate limit, but probably makes sense anyway
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await this.delay(100);
       }
       db[db.indexOf(userObj)] = userObj;
     }

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -190,6 +190,21 @@ class Utils {
   }
 
   /**
+   * @param {string} username
+   * @param {boolean} strict
+   * @returns {Promise<string|false>}
+   */
+  async usernameExists(username, strict = false) {
+    const playerData = await this.getUUID(username, true);
+    // name is valid, return correct capitalisation
+    if (playerData?.name) return playerData.name;
+    // api request failed and strict is false, return unvalidated input name
+    if (playerData === null && !strict) return username;
+    // name is invalid or request failed with strict === true, return `false`
+    return false;
+  }
+
+  /**
    * @param {import("../mineflayer/Bot.mjs").default} bot
    * @param {string} commandAlias
    * @returns {Object|null}

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -585,6 +585,7 @@ class Utils {
    *
    * @param {Object} options
    * @param {string} [options.link]
+   * @param {boolean} [options.overwrite]
    * @param {string} [options.time]
    */
   setMonthGuide(options = {}) {
@@ -597,7 +598,7 @@ class Utils {
       options.link
     )
       return;
-    if (data[options.time] && data[options.time].overwrite) return;
+    if (data[options.time]?.overwrite && !options.overwrite) return;
     data[options.time] = {
       overwrite: options.overwrite || false,
       link: options.link,


### PR DESCRIPTION
- Added `usernameExists` util function to validate a username
  - returns the unvalidated input username if the api request fails and the `strict` arg is not set
  - Replaced previous username validation logic in various commands
- Added `delay` util function as a cleaner async delay
  - directly returns a `Promise` that resolves after the given ms of timeout, instead of awaiting it inside the util function (slightly cleaner)
  - Updated all applicable `setTimeout`s in various files
- `!p cmd` now always bypasses the verbosity setting
- Added new `!p setguide` command
  - Takes a link, as well as an optional month arg (like the discord command)
- Small fixes to both the `setMonthGuide` util function, as well as the `/guide` discord command