### PR TITLE
Fixed delay issue in `!p help list` and fixed bug in `splitMessage`

### DIFF
--- a/src/mineflayer/commands/misc/Help.mjs
+++ b/src/mineflayer/commands/misc/Help.mjs
@@ -21,8 +21,8 @@ export default {
       );
       let message = `Available commands: ${bot.partyCommands.map((value, key) => key[0]).join(", ")}`;
       for (let subMessage of bot.utils.splitMessage(message, 192)) {
-        bot.reply(sender, subMessage, VerbosityLevel.Minimal);
         await bot.utils.delay(bot.utils.minMsgDelay);
+        bot.reply(sender, subMessage, VerbosityLevel.Minimal);
       }
     } else {
       const command = bot.utils.getCommandByAlias(bot, args[0]);

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -705,7 +705,7 @@ class Utils {
         message = message.slice(splitIndex + 1);
       }
       return subMessages;
-    } else return message;
+    } else return [message];
   }
 
   /**


### PR DESCRIPTION
- Fixed issue with missing delay when running `!p help list`
- Fixed incorrect behaviour of `splitMessage()` when the initial message is under the max length