### PR TITLE
Added `exportCommandData` script to output party command properties as JSON

### DIFF
--- a/one-time-scripts/exportCommandData.mjs
+++ b/one-time-scripts/exportCommandData.mjs
@@ -1,0 +1,85 @@
+import fs from "fs/promises";
+import path from "path";
+import { pathToFileURL } from "url";
+
+// adjust as needed
+const options = {
+  // path to command files
+  commandDirectoryPath: path.resolve(
+    import.meta.dirname,
+    "../src/mineflayer/commands",
+  ),
+
+  // whether to group commands into categories depending on their directory
+  sortSeparateDirectories: true,
+
+  // whether to output multi-line indented JSON
+  prettyJSON: false,
+
+  // whether to write the output to a file
+  outputToFile: false,
+
+  // path to output file
+  outputFilePath: path.resolve(import.meta.dirname, "commandData.json"),
+
+  // which command properties to include (and in which order)
+  includedProperties: {
+    name: true,
+    description: true,
+    usage: true,
+    permission: true,
+    isPartyChatCommand: false,
+    alwaysEnabled: false,
+  },
+};
+
+async function loadFilePathsRecursive(directoryPath) {
+  let files = [];
+
+  for (const file of await fs.readdir(directoryPath, { withFileTypes: true })) {
+    const filePath = path.resolve(directoryPath, file.name);
+
+    if (file.isDirectory())
+      files = files.concat(await loadFilePathsRecursive(filePath));
+    else files.push(filePath);
+  }
+
+  return files;
+}
+
+async function loadCommandData(options) {
+  const filePaths = await loadFilePathsRecursive(options.commandDirectoryPath);
+
+  let commandData = options.sortSeparateDirectories ? {} : [];
+
+  for (const filePath of filePaths) {
+    const fileData = (await import(pathToFileURL(filePath).href)).default;
+    if (!fileData.ignore) {
+      let data = {};
+      // filter properties according to options
+      Object.entries(options.includedProperties).forEach(([key, value]) => {
+        if (value) data[key] = fileData[key];
+      });
+
+      if (options.sortSeparateDirectories) {
+        const directoryName = path.basename(path.dirname(filePath));
+
+        if (!commandData[directoryName]) commandData[directoryName] = [];
+        commandData[directoryName].push(data);
+      } else commandData.push(data);
+    }
+  }
+
+  return commandData;
+}
+
+const commandJSON = JSON.stringify(
+  await loadCommandData(options),
+  null,
+  options.prettyJSON ? 2 : 0,
+);
+
+if (options.outputToFile)
+  await fs.writeFile(options.outputFilePath, commandJSON);
+
+console.log(commandJSON);


### PR DESCRIPTION
- New `exportCommandData` script to output party command properties as JSON for use in other applications
  - Directory to load commands from is configurable
  - Can output pretty (indented multi-line) or one-line JSON
  - Can optionally write the output to a file (on unix it can also just be redirected to a file using `>` :D)
  - Optionally sort commands into categories based on their directory
  - Command data to include can be customised
  - I didn't bother implementing a terminal interface, these options can be configured at the top inside the file itself