### PR TITLE
Various random changes and improvements

### DIFF
--- a/Config.example.mjs
+++ b/Config.example.mjs
@@ -27,6 +27,7 @@ export default {
   showMcChat: true,
   verbosityMc: VerbosityLevel.Full, // verbosity level for minecraft chat messages
   usernameRefreshInterval: 2 * 60 * 60 * 1000, // in milliseconds, default is 2h (2 * 60 * 60 * 1000ms)
+  persistentDisabledCommands: true, // store disabled commands in `generalDatabase.json`, persistent across restarts
   debug: {
     // IF YOU DONT KNOW WHAT YOU ARE DOING DO NOT TOUCH THIS. THIS IS MADE FOR DEVELOPERS TO DEBUG THE BOT ONLY
     general: true,

--- a/index.mjs
+++ b/index.mjs
@@ -29,6 +29,7 @@ if (config.default.debug.disableMinecraft) {
   myBot = await import("./src/mineflayer/Bot.mjs");
   myBot = myBot.default;
   myBot.setUtilClass(utils);
+  await myBot.loadCommands();
   myBot.setConfig(config.default);
 }
 

--- a/one-time-scripts/exportCommandData.mjs
+++ b/one-time-scripts/exportCommandData.mjs
@@ -29,7 +29,7 @@ const options = {
     usage: true,
     permission: true,
     isPartyChatCommand: false,
-    alwaysEnabled: false,
+    disableCommand: false,
   },
 };
 

--- a/src/discord/Discord.mjs
+++ b/src/discord/Discord.mjs
@@ -94,12 +94,15 @@ class Discord {
     let messageTimeStamp = new Date(message.createdTimestamp);
     let currentTimeStamp = new Date();
     if (messageTimeStamp.getMonth() !== currentTimeStamp.getMonth() - 1) return;
-    if (/^(https:\/\/hypixel\.net\/threads\/bingo)/.test(message.content)) {
+    const match = message.content.match(
+      /https:\/\/hypixel\.net\/threads\/bingo\S+/,
+    );
+    if (match) {
       let guide = this.utils.getMonthGuide();
       if (!guide) {
         let humanReadableMonth = messageTimeStamp.getMonth() + 2;
         this.utils.setMonthGuide({
-          link: message.content,
+          link: match[0],
           time: humanReadableMonth + "/" + messageTimeStamp.getFullYear(),
         });
       }

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -133,9 +133,11 @@ class Bot {
   }
 
   async loadCommands() {
-    this.partyCommands = this.utils.loadStoredCommandStates(
-      await loadPartyCommands(),
-    );
+    this.partyCommands = await loadPartyCommands();
+    if (this.config.persistentDisabledCommands)
+      this.partyCommands = this.utils.loadStoredCommandStates(
+        this.partyCommands,
+      );
   }
 
   /**

--- a/src/mineflayer/Bot.mjs
+++ b/src/mineflayer/Bot.mjs
@@ -18,11 +18,6 @@ class Bot {
       auth: this.config.mineflayerInfo.authType,
     });
 
-    (async () => {
-      /** @type {Collection} */
-      this.partyCommands = await loadPartyCommands();
-    })();
-
     this.bot.once("login", this.onceLogin.bind(this));
 
     this.bot.addListener("kicked", this.onKicked.bind(this));
@@ -135,6 +130,12 @@ class Bot {
   async reloadPartyCommands() {
     this.partyCommands = await loadPartyCommands();
     return true;
+  }
+
+  async loadCommands() {
+    this.partyCommands = this.utils.loadStoredCommandStates(
+      await loadPartyCommands(),
+    );
   }
 
   /**

--- a/src/mineflayer/commands/EXAMPLECOMMAND.mjs
+++ b/src/mineflayer/commands/EXAMPLECOMMAND.mjs
@@ -1,4 +1,4 @@
-import { Permissions } from "../../utils/Interfaces.mjs";
+import { DisableCommand, Permissions } from "../../utils/Interfaces.mjs";
 
 export default {
   name: ["command1", "command2"], // This command will be triggered by either command1 or command2
@@ -8,7 +8,7 @@ export default {
   permission: Permissions.Admin, // Permission level required to execute this command
   customPrefix: "", // Only use this if you want to use a custom prefix for this command, otherwise leave it empty and it'll use the default prefix
   isPartyChatCommand: false, // Set to true if the command should be used in party chat, also include the command's prefix (if applicable) in the name (e.g. '!guide')
-  alwaysEnabled: false, // Set to true for commands that should never be disabled (e.g. "!p disable")
+  disableCommand: DisableCommand.Normal, // Set to `ForceEnabled`/`UsuallyKeepEnabled` for commands that shouldn't always be disabled (refer to `Interfaces.mjs`)
   /**
    *
    * @param {import("../../Bot.mjs").default} bot

--- a/src/mineflayer/commands/admin/AddUser.mjs
+++ b/src/mineflayer/commands/admin/AddUser.mjs
@@ -1,10 +1,17 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["adduser", "user"],
-  description: "Add users to the permission list or change their permission level",
-  usage: "!p adduser <user> <(updated)permission> | !p adduser <new alt> <existing main>",
+  description:
+    "Add users to the permission list or change their permission level",
+  usage:
+    "!p adduser <user> <(updated)permission> | !p adduser <new alt> <existing main>",
   permission: Permissions.Staff,
+  disableCommand: DisableCommand.UsuallyKeepEnabled,
 
   /**
    *

--- a/src/mineflayer/commands/admin/AddUser.mjs
+++ b/src/mineflayer/commands/admin/AddUser.mjs
@@ -2,6 +2,7 @@ import {
   DisableCommand,
   Permissions,
   VerbosityLevel,
+  WebhookMessageType,
 } from "../../../utils/Interfaces.mjs";
 
 export default {
@@ -55,6 +56,11 @@ export default {
         uuid: data.uuid,
         mainAccount: mainUser,
       });
+      bot.utils.webhookLogger.addMessage(
+        `\`${data.name}\` was added to the database as \`${mainUser}\`'s alt account by \`${sender.username}\`.`,
+        WebhookMessageType.ActionLog,
+        true,
+      );
       bot.reply(
         sender,
         `Added ${data.name} as ${mainUser}'s alt.`,
@@ -96,6 +102,11 @@ export default {
         const permission = Object.keys(Permissions).find(
           (perm) => Permissions[perm] === permissionRank,
         );
+        bot.utils.webhookLogger.addMessage(
+          `\`${data.name}\`'s permission rank was updated to \`${permission}\` (level: \`${permissionRank}\`) by \`${sender.username}\`.`,
+          WebhookMessageType.ActionLog,
+          true,
+        );
         return bot.reply(
           sender,
           `Updated ${data.name}'s permission to ${permission} (level: ${permissionRank})`,
@@ -109,6 +120,11 @@ export default {
       });
       const permission = Object.keys(Permissions).find(
         (perm) => Permissions[perm] === permissionRank,
+      );
+      bot.utils.webhookLogger.addMessage(
+        `\`${data.name}\` was added to the database with permission rank \`${permission}\` (level: \`${permissionRank}\`) by \`${sender.username}\`.`,
+        WebhookMessageType.ActionLog,
+        true,
       );
       return bot.reply(
         sender,

--- a/src/mineflayer/commands/admin/Cmd.mjs
+++ b/src/mineflayer/commands/admin/Cmd.mjs
@@ -1,10 +1,15 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["cmd", "execute", "exec"],
   description: "Execute any command as the bot",
   usage: "!p cmd <command>",
   permission: Permissions.Owner,
+  disableCommand: DisableCommand.UsuallyKeepEnabled,
 
   /**
    *

--- a/src/mineflayer/commands/admin/DisableCommands.mjs
+++ b/src/mineflayer/commands/admin/DisableCommands.mjs
@@ -25,7 +25,8 @@ export default {
         commands.push(value.name[0]);
         value.disabled = true;
       });
-      bot.utils.updateStoredCommandStates(true, commands);
+      if (bot.config.persistentDisabledCommands)
+        bot.utils.updateStoredCommandStates(true, commands);
       // TODO: also console log here
       bot.reply(sender, "All commands disabled!", VerbosityLevel.Reduced);
     } else if (args[0]?.toLowerCase() === "most") {
@@ -35,7 +36,8 @@ export default {
         commands.push(value.name[0]);
         value.disabled = true;
       });
-      bot.utils.updateStoredCommandStates(true, commands);
+      if (bot.config.persistentDisabledCommands)
+        bot.utils.updateStoredCommandStates(true, commands);
       bot.reply(sender, "Most commands disabled!", VerbosityLevel.Reduced);
     } else {
       if (!args[0])
@@ -71,10 +73,11 @@ export default {
       commands.forEach((cmd) => {
         cmd.disabled = true;
       });
-      bot.utils.updateStoredCommandStates(
-        true,
-        commands.map((cmd) => cmd.name[0]),
-      );
+      if (bot.config.persistentDisabledCommands)
+        bot.utils.updateStoredCommandStates(
+          true,
+          commands.map((cmd) => cmd.name[0]),
+        );
       bot.reply(sender, "Command(s) disabled!", VerbosityLevel.Reduced);
     }
   },

--- a/src/mineflayer/commands/admin/DisableCommands.mjs
+++ b/src/mineflayer/commands/admin/DisableCommands.mjs
@@ -19,17 +19,23 @@ export default {
    */
   execute: async function (bot, sender, args) {
     if (args[0]?.toLowerCase() === "all") {
+      let commands = [];
       bot.partyCommands.forEach((value) => {
         if (value.disableCommand >= DisableCommand.ForceEnabled) return;
+        commands.push(value.name[0]);
         value.disabled = true;
       });
+      bot.utils.updateStoredCommandStates(true, commands);
       // TODO: also console log here
       bot.reply(sender, "All commands disabled!", VerbosityLevel.Reduced);
     } else if (args[0]?.toLowerCase() === "most") {
+      let commands = [];
       bot.partyCommands.forEach((value) => {
         if (value.disableCommand > DisableCommand.Normal) return;
+        commands.push(value.name[0]);
         value.disabled = true;
       });
+      bot.utils.updateStoredCommandStates(true, commands);
       bot.reply(sender, "Most commands disabled!", VerbosityLevel.Reduced);
     } else {
       if (!args[0])
@@ -65,6 +71,10 @@ export default {
       commands.forEach((cmd) => {
         cmd.disabled = true;
       });
+      bot.utils.updateStoredCommandStates(
+        true,
+        commands.map((cmd) => cmd.name[0]),
+      );
       bot.reply(sender, "Command(s) disabled!", VerbosityLevel.Reduced);
     }
   },

--- a/src/mineflayer/commands/admin/DisableCommands.mjs
+++ b/src/mineflayer/commands/admin/DisableCommands.mjs
@@ -1,11 +1,15 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["disable"],
   description: "Temporarily disable commands",
-  usage: "!p disable <command1> [command2]... | !p disable all",
+  usage: "!p disable <command1> [command2]... | !p disable <all|most>",
   permission: Permissions.Admin,
-  alwaysEnabled: true,
+  disableCommand: DisableCommand.ForceEnabled,
 
   /**
    *
@@ -14,13 +18,19 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    if (args[0] && args[0].toLowerCase() === "all") {
+    if (args[0]?.toLowerCase() === "all") {
       bot.partyCommands.forEach((value) => {
-        if (value.alwaysEnabled) return;
+        if (value.disableCommand >= DisableCommand.ForceEnabled) return;
         value.disabled = true;
       });
       // TODO: also console log here
       bot.reply(sender, "All commands disabled!", VerbosityLevel.Reduced);
+    } else if (args[0]?.toLowerCase() === "most") {
+      bot.partyCommands.forEach((value) => {
+        if (value.disableCommand > DisableCommand.Normal) return;
+        value.disabled = true;
+      });
+      bot.reply(sender, "Most commands disabled!", VerbosityLevel.Reduced);
     } else {
       if (!args[0])
         return bot.reply(
@@ -42,7 +52,11 @@ export default {
           "One or more command(s) not found.",
           VerbosityLevel.Reduced,
         );
-      if (commands.some((cmd) => cmd.alwaysEnabled))
+      if (
+        commands.some(
+          (cmd) => cmd.disableCommand >= DisableCommand.ForceEnabled,
+        )
+      )
         return bot.reply(
           sender,
           "One or more commands can't be disabled!",

--- a/src/mineflayer/commands/admin/EnableCommands.mjs
+++ b/src/mineflayer/commands/admin/EnableCommands.mjs
@@ -1,11 +1,15 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["enable"],
   description: "Re-enable disabled commands",
-  usage: "!p enable <command1> [command2]... | !p enable all",
+  usage: "!p enable <command1> [command2]... | !p enable <all|some>",
   permission: Permissions.Admin,
-  alwaysEnabled: true,
+  disableCommand: DisableCommand.ForceEnabled,
 
   /**
    *
@@ -14,15 +18,24 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    if (args[0] && args[0].toLowerCase() === "all") {
+    if (args[0]?.toLowerCase() === "all") {
       bot.partyCommands.forEach((value) => {
-        if (value.alwaysEnabled) return;
         value.disabled = false;
       });
       // TODO: also console log here
       bot.reply(
         sender,
         "All commands have been enabled!",
+        VerbosityLevel.Reduced,
+      );
+    } else if (args[0]?.toLowerCase() === "some") {
+      bot.partyCommands.forEach((value) => {
+        if (value.disableCommand > DisableCommand.Normal)
+          value.disabled = false;
+      });
+      bot.reply(
+        sender,
+        "Some commands have been enabled!",
         VerbosityLevel.Reduced,
       );
     } else {
@@ -46,7 +59,11 @@ export default {
           "One or more command(s) not found.",
           VerbosityLevel.Reduced,
         );
-      if (commands.some((cmd) => cmd.alwaysEnabled))
+      if (
+        commands.some(
+          (cmd) => cmd.disableCommand >= DisableCommand.ForceEnabled,
+        )
+      )
         return bot.reply(
           sender,
           "One or more commands are always enabled!",

--- a/src/mineflayer/commands/admin/EnableCommands.mjs
+++ b/src/mineflayer/commands/admin/EnableCommands.mjs
@@ -19,9 +19,12 @@ export default {
    */
   execute: async function (bot, sender, args) {
     if (args[0]?.toLowerCase() === "all") {
+      let commands = [];
       bot.partyCommands.forEach((value) => {
         value.disabled = false;
+        commands.push(value.name[0]);
       });
+      bot.utils.updateStoredCommandStates(false, commands);
       // TODO: also console log here
       bot.reply(
         sender,
@@ -29,10 +32,14 @@ export default {
         VerbosityLevel.Reduced,
       );
     } else if (args[0]?.toLowerCase() === "some") {
+      let commands = [];
       bot.partyCommands.forEach((value) => {
-        if (value.disableCommand > DisableCommand.Normal)
+        if (value.disableCommand > DisableCommand.Normal) {
           value.disabled = false;
+          commands.push(value.name[0]);
+        }
       });
+      bot.utils.updateStoredCommandStates(false, commands);
       bot.reply(
         sender,
         "Some commands have been enabled!",
@@ -72,6 +79,10 @@ export default {
       commands.forEach((cmd) => {
         cmd.disabled = false;
       });
+      bot.utils.updateStoredCommandStates(
+        false,
+        commands.map((cmd) => cmd.name[0]),
+      );
       bot.reply(sender, "Command(s) enabled!", VerbosityLevel.Reduced);
     }
   },

--- a/src/mineflayer/commands/admin/EnableCommands.mjs
+++ b/src/mineflayer/commands/admin/EnableCommands.mjs
@@ -24,7 +24,8 @@ export default {
         value.disabled = false;
         commands.push(value.name[0]);
       });
-      bot.utils.updateStoredCommandStates(false, commands);
+      if (bot.config.persistentDisabledCommands)
+        bot.utils.updateStoredCommandStates(false, commands);
       // TODO: also console log here
       bot.reply(
         sender,
@@ -39,7 +40,8 @@ export default {
           commands.push(value.name[0]);
         }
       });
-      bot.utils.updateStoredCommandStates(false, commands);
+      if (bot.config.persistentDisabledCommands)
+        bot.utils.updateStoredCommandStates(false, commands);
       bot.reply(
         sender,
         "Some commands have been enabled!",
@@ -79,10 +81,11 @@ export default {
       commands.forEach((cmd) => {
         cmd.disabled = false;
       });
-      bot.utils.updateStoredCommandStates(
-        false,
-        commands.map((cmd) => cmd.name[0]),
-      );
+      if (bot.config.persistentDisabledCommands)
+        bot.utils.updateStoredCommandStates(
+          false,
+          commands.map((cmd) => cmd.name[0]),
+        );
       bot.reply(sender, "Command(s) enabled!", VerbosityLevel.Reduced);
     }
   },

--- a/src/mineflayer/commands/admin/ListDisabledCommands.mjs
+++ b/src/mineflayer/commands/admin/ListDisabledCommands.mjs
@@ -1,11 +1,15 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["listdisabled", "disabled", "lsdisabled", "lsoff"],
   description: "List currently disabled commands",
   usage: "!p listdisabled",
   permission: Permissions.Admin,
-  alwaysEnabled: true,
+  disableCommand: DisableCommand.ForceEnabled,
 
   /**
    *

--- a/src/mineflayer/commands/admin/QueryUser.mjs
+++ b/src/mineflayer/commands/admin/QueryUser.mjs
@@ -33,10 +33,11 @@ export default {
     const rank = Object.keys(Permissions).find(
       (perm) => Permissions[perm] === userObj.permissionRank,
     );
-    // Get name with correct capitalisation
-    const username = userObj.accounts.find(
-      (acc) => acc.name.toLowerCase() === user.toLowerCase(),
-    ).name;
+    // Get main account
+    const username = bot.utils.getPreferredUsername({
+      name: user,
+      forceHideRank: true,
+    });
     // Get user's other accounts
     const alts = userObj.accounts
       .map((acc) => acc.name)

--- a/src/mineflayer/commands/admin/RemoveUser.mjs
+++ b/src/mineflayer/commands/admin/RemoveUser.mjs
@@ -1,4 +1,8 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  Permissions,
+  VerbosityLevel,
+  WebhookMessageType,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["removeuser"],
@@ -34,12 +38,23 @@ export default {
         VerbosityLevel.Reduced,
       );
     bot.utils.removeUser({ name: user, onlyThis: only });
-    if (only)
+    if (only) {
+      bot.utils.webhookLogger.addMessage(
+        `\`${user}\` was removed from the database (without impacting their other accounts) by \`${sender.username}\`.`,
+        WebhookMessageType.ActionLog,
+        true,
+      );
       return bot.reply(
         sender,
         `Removed account ${user}, but kept other alts.`,
         VerbosityLevel.Reduced,
       );
+    }
+    bot.utils.webhookLogger.addMessage(
+      `\`${user}\` and all their other accounts were removed from the database by \`${sender.username}\`.`,
+      WebhookMessageType.ActionLog,
+      true,
+    );
     bot.reply(
       sender,
       `Removed user ${user} and all their other accounts.`,

--- a/src/mineflayer/commands/misc/Help.mjs
+++ b/src/mineflayer/commands/misc/Help.mjs
@@ -1,10 +1,15 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["help"],
   description: "Get info about available commands",
   usage: "!p help list | !p help <command>",
   permission: Permissions.HoB,
+  disableCommand: DisableCommand.UsuallyKeepEnabled,
 
   /**
    *

--- a/src/mineflayer/commands/misc/Link.mjs
+++ b/src/mineflayer/commands/misc/Link.mjs
@@ -1,4 +1,8 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["link"],
@@ -6,6 +10,7 @@ export default {
     "Link your accounts by entering a discord code obtained from '/link'",
   usage: "!p link <discord code>",
   permission: Permissions.Trusted,
+  disableCommand: DisableCommand.UsuallyKeepEnabled,
 
   /**
    *

--- a/src/mineflayer/commands/misc/Test.mjs
+++ b/src/mineflayer/commands/misc/Test.mjs
@@ -1,10 +1,15 @@
-import { Permissions, VerbosityLevel } from "../../../utils/Interfaces.mjs";
+import {
+  DisableCommand,
+  Permissions,
+  VerbosityLevel,
+} from "../../../utils/Interfaces.mjs";
 
 export default {
   name: ["test", "testpermissions", "testperms", "testcommand", "boopme"],
   description:
     "See whether you are on the permission list, and what permissions you have",
   usage: "!p test",
+  disableCommand: DisableCommand.UsuallyKeepEnabled,
   // command can't have a permission requirement, otherwise any uuid fetching here is pointless as db permission checks would prevent it from executing in the first place
   // there still isn't any output without being in the db
 

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -18,7 +18,7 @@ export default {
     let dontRepeat = false;
 
     // first arg (hub number)
-    if (!isNaN(args[0])) {
+    if (args[0] && !isNaN(args[0])) {
       const hubNumber = parseInt(args[0]);
       if (hubNumber < 1 || hubNumber > 28)
         return bot.reply(sender, "Invalid hub number!", VerbosityLevel.Reduced);

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -16,22 +16,30 @@ export default {
   execute: async function (bot, sender, args) {
     let message;
     let dontRepeat = false;
+
+    // first arg (hub number)
     if (!isNaN(args[0])) {
       const hubNumber = parseInt(args[0]);
       if (hubNumber < 1 || hubNumber > 28)
         return bot.reply(sender, "Invalid hub number!", VerbosityLevel.Reduced);
-      const match = args[1]?.match(/^(mega|mini|M|m)\d{1,4}[A-Z]{1,2}$/);
+
+      // check for and extract hub ID
+      const match = args[1]?.match(
+        /^\(?(mega|mini|M|m)(\d{1,4}[A-Za-z]{1,2})\)?$/,
+      );
       let hubID;
       // convert `M`/`m` to `mega`/`mini`
-      if (match?.[1] === "M") hubID = "mega" + match[0].slice(1);
-      else if (match?.[1] === "m") hubID = "mini" + match[0].slice(1);
-      else hubID = match?.[0];
+      if (match?.[1] === "M") hubID = "mega" + match[2].toUpperCase();
+      else if (match?.[1] === "m") hubID = "mini" + match[2].toUpperCase();
+      else if (match) hubID = match[1] + match[2].toUpperCase();
+
       message = `${sender.preferredName} is splashing in Hub ${hubNumber}${hubID ? ` (${hubID})` : ""} soon!`;
     } else if (/^\/p join \w{3,16}/.test(args.join(" "))) {
       // validate username for /p join
       let pjoinUsername = await bot.utils.usernameExists(args[2]);
       if (pjoinUsername === false)
         return bot.reply(sender, "Username not found.", VerbosityLevel.Reduced);
+
       message = `${sender.preferredName} is splashing soon! Run '/p join ${pjoinUsername}' to get warped!`;
     } else if (args[0] === "switch" && !isNaN(args[1])) {
       // announce hub has shifted
@@ -46,6 +54,7 @@ export default {
         `Invalid usage! Use: ${this.usage}`,
         VerbosityLevel.Reduced,
       );
+
     if (dontRepeat)
       bot.utils
         .getCommandByAlias(bot, "say")

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -49,10 +49,10 @@ export default {
     if (dontRepeat)
       bot.utils
         .getCommandByAlias(bot, "say")
-        .execute(bot, null, message.split(" "));
+        .execute(bot, sender, message.split(" "), this);
     else
       bot.utils
         .getCommandByAlias(bot, "flea")
-        .execute(bot, null, message.split(" "));
+        .execute(bot, sender, message.split(" "), this);
   },
 };

--- a/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
@@ -14,7 +14,7 @@ export default {
    * @param {String} sender
    * @param {Array<String>} args
    */
-  execute: async function (bot, sender, args) {
+  execute: async function (bot, sender, args, callerCommand = null) {
     // This commands produces a splash message to party chat, "BossFlea style":
     // 4 repetitions à 4 seconds apart, then a pause of 20 seconds, then a
     // final fifth one
@@ -22,15 +22,22 @@ export default {
     if (args.length < 1)
       return bot.reply(
         sender,
-        `Invalid usage! Use: ${this.usage}`,
+        `Invalid usage! Use: ${callerCommand ? callerCommand.usage : this.usage}`,
         VerbosityLevel.Reduced,
       );
 
     bot.utils
       .getCommandByAlias(bot, "repeat")
-      .execute(bot, sender, `4 4 ${args.join(" ")}`.split(" "));
+      .execute(
+        bot,
+        sender,
+        `4 4 ${args.join(" ")}`.split(" "),
+        callerCommand ?? this,
+      );
 
     await bot.utils.delay(12_000 + 20_000);
-    bot.utils.getCommandByAlias(bot, "say").execute(bot, sender, args);
+    bot.utils
+      .getCommandByAlias(bot, "say")
+      .execute(bot, sender, args, callerCommand ?? this);
   },
 };

--- a/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
@@ -14,7 +14,7 @@ export default {
    * @param {String} sender
    * @param {Array<String>} args
    */
-  execute: async function (bot, sender, args) {
+  execute: async function (bot, sender, args, callerCommand = null) {
     let repetitions = parseInt(args[0]);
     let duration = parseFloat(args[1]);
     let startIndex = 2;
@@ -33,14 +33,14 @@ export default {
     if (args.length < 1 + startIndex)
       return bot.reply(
         sender,
-        `Invalid command usage! Use: ${this.usage}`,
+        `Invalid command usage! Use: ${callerCommand ? callerCommand.usage : this.usage}`,
         VerbosityLevel.Reduced,
       );
 
     for (let i = 0; i < repetitions; i++) {
       bot.utils
         .getCommandByAlias(bot, "say")
-        .execute(bot, sender, args.slice(startIndex));
+        .execute(bot, sender, args.slice(startIndex), callerCommand ?? this);
       await bot.utils.delay(duration * 1000);
     }
   },

--- a/src/mineflayer/commands/party/chatunrestricted/Say.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Say.mjs
@@ -13,11 +13,11 @@ export default {
    * @param {String} sender
    * @param {Array<String>} args
    */
-  execute: async function (bot, sender, args) {
+  execute: async function (bot, sender, args, callerCommand = null) {
     if (args.length < 1) {
       bot.reply(
         sender,
-        `Invalid command usage! Use: ${this.usage}`,
+        `Invalid command usage! Use: ${callerCommand ? callerCommand.usage : this.usage}`,
         VerbosityLevel.Reduced,
       );
       return;

--- a/src/utils/Interfaces.mjs
+++ b/src/utils/Interfaces.mjs
@@ -68,3 +68,9 @@ export const VerbosityLevel = Object.freeze({
   Reduced: 2, // reduce optional messages (remove most party messages, keep most dm command feedback for better ux)
   Full: 3, // all messages
 });
+
+export const DisableCommand = Object.freeze({
+  Normal: 0, // Disable command normally and using `!p disable most`
+  UsuallyKeepEnabled: 1, // Disable command only using `!p disable all`, ignore `most`
+  ForceEnabled: 2, // Never disable command (even manually)
+});

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -116,6 +116,39 @@ class Utils {
     }, 10000);
   }
 
+  /**
+   *
+   * @param {Collection} partyCommands
+   * @returns {Collection}
+   */
+  loadStoredCommandStates(partyCommands) {
+    const disabledCommands = this.generalDatabase.get("disabledCommands") ?? [];
+    partyCommands.forEach((command, key) => {
+      command.disabled = disabledCommands.includes(command.name[0]);
+      partyCommands.set(key, command);
+    });
+    return partyCommands;
+  }
+
+  /**
+   *
+   * @param {Boolean} newDisabled
+   * @param {Array<String>} commandNames
+   */
+  updateStoredCommandStates(newDisabled, commandNames) {
+    const disabledCommands = this.generalDatabase.get("disabledCommands") ?? [];
+    if (newDisabled)
+      for (const command of commandNames) {
+        if (!disabledCommands.includes(command)) disabledCommands.push(command);
+      }
+    else
+      for (const command of commandNames) {
+        if (disabledCommands.includes(command))
+          disabledCommands.splice(disabledCommands.indexOf(command), 1);
+      }
+    this.generalDatabase.set("disabledCommands", disabledCommands);
+  }
+
   async updateAllFromUUID(bot) {
     const startTimestamp = Date.now();
     this.log("Started refreshing all stored usernames from UUID...", "Info");

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -394,16 +394,17 @@ class Utils {
     if (!userObj) return null;
     let db = this.playerNamesDatabase.get("data");
     if (options.onlyThis) {
+      // reset preferredAccount if it's the removed account
+      if (
+        userObj.accounts.find(
+	  (acc) => acc.name.toLowerCase() === options.name.toLowerCase(),
+	).uuid === userObj.preferredAccount
+      )
+        delete userObj.preferredAccount;
       // Only remove this account, leave other alts intact
       userObj.accounts = userObj.accounts.filter(
         (acc) => acc.name.toLowerCase() !== options.name.toLowerCase(),
       );
-      // reset preferredAccount if it's the removed account
-      if (
-        userObj.accounts.find((acc) => acc.name === options.name).uuid ===
-        userObj.preferredAccount
-      )
-        delete userObj.preferredAccount;
       db[db.indexOf(userObj)] = userObj;
     }
     // Remove the entire user

--- a/src/utils/Utils.mjs
+++ b/src/utils/Utils.mjs
@@ -459,7 +459,7 @@ class Utils {
    * @param {String} [options.uuid]
    * @param {String} [options.name]
    * @param {String} [options.discord]
-   * @param {String} [options.forceHideRank]
+   * @param {Boolean} [options.forceHideRank]
    * @returns {String|null}
    */
   getPreferredUsername(options = {}) {


### PR DESCRIPTION
- Added `callerCommand` arg to some party commands to allow for displaying a different usage string when called from another command internally (e.g. `!p splash` internally uses `!p say`)
- `!p query` now always shows the person's main account (preferredAccount) first, even when querying an alt
- The hub ID in `!p splash` now supports lowercase letters (convenience) and surrounding brackets
  - This makes it possible to type `/b` (or another `/msg bingoparty !p` alias) and click the hub paste button from Bingo+ to have `/b Hub 16 (mega2B)` in chat, which is a valid command
- Fixed an issue where the output of `!p splash` showed `NaN` as the hub number
- Improved the discord guide link fetching logic
  - Now detects the link anywhere in the message, not just messages consisting of only the link
- Added `!p disable most` and `!p enable some` to disable everything except or enable only certain commands, respectively
  - Replaced the `alwaysEnabled` property on party commands by the `disableCommand` property, corresponding to one of `DisableCommand.Normal`, `.UsuallyKeepEnabled` or `.ForceEnabled` in `Interfaces.mjs`
    - Defaults to `.Normal`, so it's only necessary to add this to commands that need special treatment
    - For now `cmd`, `adduser`, `test`, `help` and `link` are `.UsuallyKeepEnabled`, taken from #78 
  - Updated `exportCommandData` script to support this new property
- Disabled commands are now persistent across restarts
  - Names of disabled commands are stored in `generalDatabase.json` and retrieved/updated on startup/command usage
  - Added config option to disable persistent storage
  - Added logging to `ActionLog` webhooks when a user is added/removed/modified in the database