### PR TITLE
Fixed duplicate ign in `!p splash` output message, bundled optional internal command args

### DIFF
--- a/src/mineflayer/commands/party/Guide.mjs
+++ b/src/mineflayer/commands/party/Guide.mjs
@@ -15,8 +15,14 @@ export default {
    * @param {import("../../Bot.mjs").default} bot
    * @param {String} sender
    * @param {Array<String>} args
+   * @param {Boolean} internalOptions.isPublicCommand
    */
-  execute: async function (bot, sender, args, isPublicCommand = false) {
+  execute: async function (
+    bot,
+    sender,
+    args,
+    internalOptions = { isPublicCommand: false },
+  ) {
     const currentTime = Date.now();
 
     if (currentTime - lastGuideSentTime < COOLDOWN_DURATION) {
@@ -30,7 +36,7 @@ export default {
         "Not posting guide again. (<30s passed since last share message)",
         "Info",
       );
-      if (!isPublicCommand) {
+      if (!internalOptions.isPublicCommand) {
         bot.reply(
           sender,
           `Guide command is on cooldown!`,
@@ -55,7 +61,7 @@ export default {
     if (!guide.link) {
       // Prevent _ever_ outputting empty "Party > [MVP++] BingoParty: Guide: "
       bot.utils.log("Absolutely no guide available!", "Warn");
-      if (!isPublicCommand) {
+      if (!internalOptions.isPublicCommand) {
         // `Permissions.BotAccount === Permissions.Owner`, so the bot has to be filtered out first
         // Then take the first remaining user, as only one owner is expected
         const botAccountOwner = bot.utils.getPreferredUsername({

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -58,10 +58,10 @@ export default {
     if (dontRepeat)
       bot.utils
         .getCommandByAlias(bot, "say")
-        .execute(bot, sender, message.split(" "), this);
+        .execute(bot, sender, message.split(" "), this, false);
     else
       bot.utils
         .getCommandByAlias(bot, "flea")
-        .execute(bot, sender, message.split(" "), this);
+        .execute(bot, sender, message.split(" "), this, false);
   },
 };

--- a/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
+++ b/src/mineflayer/commands/party/chatpresets/AnnounceSplash.mjs
@@ -58,10 +58,16 @@ export default {
     if (dontRepeat)
       bot.utils
         .getCommandByAlias(bot, "say")
-        .execute(bot, sender, message.split(" "), this, false);
+        .execute(bot, sender, message.split(" "), {
+          callerCommand: this,
+          includePrefix: false,
+        });
     else
       bot.utils
         .getCommandByAlias(bot, "flea")
-        .execute(bot, sender, message.split(" "), this, false);
+        .execute(bot, sender, message.split(" "), {
+          callerCommand: this,
+          includePrefix: false,
+        });
   },
 };

--- a/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
@@ -20,7 +20,7 @@ export default {
     bot,
     sender,
     args,
-    internalOptions = { callerCommand: null, includePrefix: true },
+    internalOptions = { callerCommand: this, includePrefix: true },
   ) {
     // This commands produces a splash message to party chat, "BossFlea style":
     // 4 repetitions à 4 seconds apart, then a pause of 20 seconds, then a
@@ -29,7 +29,7 @@ export default {
     if (args.length < 1)
       return bot.reply(
         sender,
-        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage ?? this.usage}`,
+        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage}`,
         VerbosityLevel.Reduced,
       );
 

--- a/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
@@ -14,7 +14,13 @@ export default {
    * @param {String} sender
    * @param {Array<String>} args
    */
-  execute: async function (bot, sender, args, callerCommand = null) {
+  execute: async function (
+    bot,
+    sender,
+    args,
+    callerCommand = null,
+    includePrefix = true,
+  ) {
     // This commands produces a splash message to party chat, "BossFlea style":
     // 4 repetitions à 4 seconds apart, then a pause of 20 seconds, then a
     // final fifth one
@@ -33,11 +39,12 @@ export default {
         sender,
         `4 4 ${args.join(" ")}`.split(" "),
         callerCommand ?? this,
+        includePrefix,
       );
 
     await bot.utils.delay(12_000 + 20_000);
     bot.utils
       .getCommandByAlias(bot, "say")
-      .execute(bot, sender, args, callerCommand ?? this);
+      .execute(bot, sender, args, callerCommand ?? this, includePrefix);
   },
 };

--- a/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Flea.mjs
@@ -13,13 +13,14 @@ export default {
    * @param {import("../../../Bot.mjs").default} bot
    * @param {String} sender
    * @param {Array<String>} args
+   * @param {import("../../EXAMPLECOMMAND.mjs").default} internalOptions.callerCommand
+   * @param {Boolean} internalOptions.includePrefix
    */
   execute: async function (
     bot,
     sender,
     args,
-    callerCommand = null,
-    includePrefix = true,
+    internalOptions = { callerCommand: null, includePrefix: true },
   ) {
     // This commands produces a splash message to party chat, "BossFlea style":
     // 4 repetitions à 4 seconds apart, then a pause of 20 seconds, then a
@@ -28,7 +29,7 @@ export default {
     if (args.length < 1)
       return bot.reply(
         sender,
-        `Invalid usage! Use: ${callerCommand ? callerCommand.usage : this.usage}`,
+        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage ?? this.usage}`,
         VerbosityLevel.Reduced,
       );
 
@@ -38,13 +39,12 @@ export default {
         bot,
         sender,
         `4 4 ${args.join(" ")}`.split(" "),
-        callerCommand ?? this,
-        includePrefix,
+        internalOptions,
       );
 
     await bot.utils.delay(12_000 + 20_000);
     bot.utils
       .getCommandByAlias(bot, "say")
-      .execute(bot, sender, args, callerCommand ?? this, includePrefix);
+      .execute(bot, sender, args, internalOptions);
   },
 };

--- a/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
@@ -14,7 +14,13 @@ export default {
    * @param {String} sender
    * @param {Array<String>} args
    */
-  execute: async function (bot, sender, args, callerCommand = null) {
+  execute: async function (
+    bot,
+    sender,
+    args,
+    callerCommand = null,
+    includePrefix = true,
+  ) {
     let repetitions = parseInt(args[0]);
     let duration = parseFloat(args[1]);
     let startIndex = 2;
@@ -40,7 +46,13 @@ export default {
     for (let i = 0; i < repetitions; i++) {
       bot.utils
         .getCommandByAlias(bot, "say")
-        .execute(bot, sender, args.slice(startIndex), callerCommand ?? this);
+        .execute(
+          bot,
+          sender,
+          args.slice(startIndex),
+          callerCommand ?? this,
+          includePrefix,
+        );
       await bot.utils.delay(duration * 1000);
     }
   },

--- a/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
@@ -13,13 +13,14 @@ export default {
    * @param {import("../../../Bot.mjs").default} bot
    * @param {String} sender
    * @param {Array<String>} args
+   * @param {import("../../EXAMPLECOMMAND.mjs").default} internalOptions.callerCommand
+   * @param {Boolean} internalOptions.includePrefix
    */
   execute: async function (
     bot,
     sender,
     args,
-    callerCommand = null,
-    includePrefix = true,
+    internalOptions = { callerCommand: null, includePrefix: true },
   ) {
     let repetitions = parseInt(args[0]);
     let duration = parseFloat(args[1]);
@@ -39,20 +40,14 @@ export default {
     if (args.length < 1 + startIndex)
       return bot.reply(
         sender,
-        `Invalid command usage! Use: ${callerCommand ? callerCommand.usage : this.usage}`,
+        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage ?? this.usage}`,
         VerbosityLevel.Reduced,
       );
 
     for (let i = 0; i < repetitions; i++) {
       bot.utils
         .getCommandByAlias(bot, "say")
-        .execute(
-          bot,
-          sender,
-          args.slice(startIndex),
-          callerCommand ?? this,
-          includePrefix,
-        );
+        .execute(bot, sender, args.slice(startIndex), internalOptions);
       await bot.utils.delay(duration * 1000);
     }
   },

--- a/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Repeat.mjs
@@ -20,7 +20,7 @@ export default {
     bot,
     sender,
     args,
-    internalOptions = { callerCommand: null, includePrefix: true },
+    internalOptions = { callerCommand: this, includePrefix: true },
   ) {
     let repetitions = parseInt(args[0]);
     let duration = parseFloat(args[1]);
@@ -40,7 +40,7 @@ export default {
     if (args.length < 1 + startIndex)
       return bot.reply(
         sender,
-        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage ?? this.usage}`,
+        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage}`,
         VerbosityLevel.Reduced,
       );
 

--- a/src/mineflayer/commands/party/chatunrestricted/Say.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Say.mjs
@@ -12,24 +12,25 @@ export default {
    * @param {import("../../../Bot.mjs").default} bot
    * @param {String} sender
    * @param {Array<String>} args
+   * @param {import("../../EXAMPLECOMMAND.mjs").default} internalOptions.callerCommand
+   * @param {Boolean} internalOptions.includePrefix
    */
   execute: async function (
     bot,
     sender,
     args,
-    callerCommand = null,
-    includePrefix = true,
+    internalOptions = { callerCommand: null, includePrefix: true },
   ) {
     if (args.length < 1) {
       bot.reply(
         sender,
-        `Invalid command usage! Use: ${callerCommand ? callerCommand.usage : this.usage}`,
+        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage ?? this.usage}`,
         VerbosityLevel.Reduced,
       );
       return;
     }
     bot.chat(
-      `/pc ${sender?.preferredName && includePrefix ? `${sender.preferredName}: ` : ""}${args.join(" ")}`,
+      `/pc ${sender?.preferredName && internalOptions.includePrefix ? `${sender.preferredName}: ` : ""}${args.join(" ")}`,
       VerbosityLevel.Minimal,
     );
   },

--- a/src/mineflayer/commands/party/chatunrestricted/Say.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Say.mjs
@@ -13,7 +13,13 @@ export default {
    * @param {String} sender
    * @param {Array<String>} args
    */
-  execute: async function (bot, sender, args, callerCommand = null) {
+  execute: async function (
+    bot,
+    sender,
+    args,
+    callerCommand = null,
+    includePrefix = true,
+  ) {
     if (args.length < 1) {
       bot.reply(
         sender,
@@ -23,7 +29,7 @@ export default {
       return;
     }
     bot.chat(
-      `/pc ${sender?.preferredName ? `${sender.preferredName}: ` : ""}${args.join(" ")}`,
+      `/pc ${sender?.preferredName && includePrefix ? `${sender.preferredName}: ` : ""}${args.join(" ")}`,
       VerbosityLevel.Minimal,
     );
   },

--- a/src/mineflayer/commands/party/chatunrestricted/Say.mjs
+++ b/src/mineflayer/commands/party/chatunrestricted/Say.mjs
@@ -19,12 +19,12 @@ export default {
     bot,
     sender,
     args,
-    internalOptions = { callerCommand: null, includePrefix: true },
+    internalOptions = { callerCommand: this, includePrefix: true },
   ) {
     if (args.length < 1) {
       bot.reply(
         sender,
-        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage ?? this.usage}`,
+        `Invalid command usage! Use: ${internalOptions?.callerCommand?.usage}`,
         VerbosityLevel.Reduced,
       );
       return;

--- a/src/mineflayer/commands/party/public/PublicGuide.mjs
+++ b/src/mineflayer/commands/party/public/PublicGuide.mjs
@@ -2,7 +2,8 @@ import { Permissions } from "../../../../utils/Interfaces.mjs";
 
 export default {
   name: ["!guide", "!gd"],
-  description: "Send this month's bingo guide link in party chat (public command)",
+  description:
+    "Send this month's bingo guide link in party chat (public command)",
   usage: "!guide",
   isPartyChatCommand: true,
 
@@ -13,6 +14,8 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    bot.utils.getCommandByAlias(bot, "guide").execute(bot, sender, args, true);
+    bot.utils
+      .getCommandByAlias(bot, "guide")
+      .execute(bot, sender, args, { isPublicCommand: true });
   },
 };


### PR DESCRIPTION
- Fixed an oversight which caused `!p say` to prefix messages from `!p splash` with the player's ign, resulting in it being present twice
- Added `internalOptions` arg to relevant commands, replacing and bundling various optional, internal args into one options object