### PR TITLE
Shifted around (un)banning / kicking logic; removed user permissions upon banning; default ban duration; very wip temporary ban option

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -42,7 +42,9 @@ if (config.default.debug.disableDiscord) {
   discordBot.setUtils(utils);
   discordBot.setConfig(config.default);
 }
+
 refreshConfig();
+refreshBanRegistry();
 
 // Used to refresh allowList every 10 seconds
 function refreshConfig() {
@@ -59,6 +61,23 @@ function refreshConfig() {
       console.error("Error updating allowlist:", error);
     }
   }, 10000);
+}
+
+// Used to refresh banRegistry every 60 seconds
+function refreshBanRegistry() {
+  setInterval(async () => {
+    try {
+      const now = Date.now();
+      for (const [username, banData] of Object.entries(registry.bans)) {
+        if (banData.banEnd !== Infinity && banData.banEnd.getTime() <= now) {
+          delete registry.bans[username];
+          console.log(`Ban for ${username} has expired and was removed.`);
+        }
+      }
+    } catch (error) {
+      console.error("Error refreshing ban registry:", error);
+    }
+  }, 60000);
 }
 
 process.stdin.on("data", dataInput);

--- a/src/mineflayer/commands/party/Ban.mjs
+++ b/src/mineflayer/commands/party/Ban.mjs
@@ -36,11 +36,20 @@ export default {
       const playerPerms = Object.keys(Permissions).find(
         (perm) => Permissions[perm] === playerPermsRank,
       );
-      return bot.reply(
-        sender,
-        `You cannot ban a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPermsRank}).`,
-        VerbosityLevel.Reduced,
-      );
+      if (senderPerms === undefined) return;
+      else if (senderPermsRank === playerPermsRank) {
+        return bot.reply(
+          sender,
+          `You cannot ban a player of the same permission level (both: ${senderPerms}).`,
+          VerbosityLevel.Reduced,
+        );
+      } else {
+        return bot.reply(
+          sender,
+          `You cannot ban a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPermsRank})).`,
+          VerbosityLevel.Reduced,
+        );
+      }
     }
     
     bot.reply(sender, `Trying to ban ${player}...`, VerbosityLevel.Reduced);

--- a/src/mineflayer/commands/party/Ban.mjs
+++ b/src/mineflayer/commands/party/Ban.mjs
@@ -18,29 +18,66 @@ export default {
    */
   execute: async function (bot, sender, args) {
     let player = args[0];
-    if (!player)
+    if (!player) {
+      return bot.reply(sender, `Invalid usage! Use: ${this.usage}`, VerbosityLevel.Reduced);
+    }
+    const playerExists = await bot.utils.usernameExists(player);
+    if (playerExists === false) {
+      return bot.reply(sender, `Player ${player} not found`, VerbosityLevel.Reduced);
+    }
+    const reason = args.slice(1).join(" ") || "No reason given.";
+      
+    if (!bot.utils.isHigherRanked(sender.username, player)) {
+      const senderPermsRank = bot.utils.getPermissionsByUser({ name: sender.username });
+      const playerPermsRank = bot.utils.getPermissionsByUser({ name: player });
+      const senderPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === senderPermsRank,
+      );
+      const playerPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === playerPermsRank,
+      );
       return bot.reply(
         sender,
-        `Invalid usage! Use: ${this.usage}`,
+        `You cannot ban a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPermsRank}).`,
         VerbosityLevel.Reduced,
       );
-    let reason = args.slice(1).join(" ") || "No reason given.";
-    if (!bot.utils.isHigherRanked(sender.username, player)) {
-      return;
     }
-    bot.chat(
-      `/pc ${player} was removed from the party and blocked from rejoining by ${sender.preferredName}.`,
-    );
+    
+    bot.reply(sender, `Trying to ban ${player}...`, VerbosityLevel.Reduced);
+    
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/lobby`);
     await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(`/block add ${player}`);
+    await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/p kick ${player}`);
     await bot.utils.delay(bot.utils.minMsgDelay);
-    bot.chat(`/block add ${player}`);
+    bot.reply(sender, `Banned ${player}.`, VerbosityLevel.Reduced);
+
+    await bot.utils.delay(bot.utils.minMsgDelay);
+    bot.chat(
+      `/pc ${player} was removed from the party and blocked from rejoining by ${sender.preferredName}.`,
+    );
+
     bot.utils.webhookLogger.addMessage(
       `\`${player}\` was banned from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
       WebhookMessageType.ActionLog,
       true,
     );
+
+    if (bot.utils.getUserObject({ name: player })) {
+      bot.utils.setPermissionRank({
+        name: player,
+        newPermissionRank: 0,
+      });
+      const newPlayerPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === newPermissionRank,
+      );
+      bot.utils.webhookLogger.addMessage(
+        `After banning, \`${player}\`'s permission rank was updated to \`${newPlayerPerms}\` (level: \`${newPermissionRank}\`) by \`${sender.username}\`.`,
+        WebhookMessageType.ActionLog,
+        true,
+      );
+    }
   },
 };

--- a/src/mineflayer/commands/party/Kick.mjs
+++ b/src/mineflayer/commands/party/Kick.mjs
@@ -7,7 +7,7 @@ import {
 export default {
   name: ["kick", "remove"],
   description: "Kick someone from the party",
-  usage: "!p kick <username>",
+  usage: "!p kick <username> [reason]",
   permission: Permissions.Trusted,
 
   /**
@@ -17,26 +17,44 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    let player;
-    if (args[0]) {
-      player = await bot.utils.usernameExists(args[0]);
-      if (player === false)
-        return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-    } else
-      return bot.reply(
-        sender,
-        `Invalid usage! Use: ${this.usage}`,
-        VerbosityLevel.Reduced,
-      );
-    let reason = args.slice(1).join(" ") || "No reason given.";
-    if (!bot.utils.isHigherRanked(sender.username, player)) {
-      return;
+    let player = args[0];
+    if (!player) {
+      return bot.reply(sender, `Invalid usage! Use: ${this.usage}`, VerbosityLevel.Reduced);
     }
+    const playerExists = await bot.utils.usernameExists(player);
+    if (playerExists === false) {
+        return bot.reply(sender, `Player ${player} not found.`, VerbosityLevel.Reduced);
+    }
+    const reason = args.slice(1).join(" ") || "No reason given.";
+    
+    if (!bot.utils.isHigherRanked(sender.username, player)) {
+      const senderPermsRank = bot.utils.getPermissionsByUser({ name: sender.username });
+      const playerPermsRank = bot.utils.getPermissionsByUser({ name: player });
+      const senderPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === senderPermsRank,
+      );
+      const playerPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === playerPermsRank,
+      );
+      if (senderPerms === undefined) return;
+      else {
+        return bot.reply(
+          sender,
+          `You cannot kick a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPermsRank})).`,
+          VerbosityLevel.Reduced,
+        );
+      }
+    }
+
+    await bot.utils.delay(bot.utils.MinMsgDelay);
+    bot.chat(`/lobby`);
+    await bot.utils.delay(bot.utils.MinMsgDelay);
+    bot.chat(`/p kick ${player}`);
+    await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(
       `/pc ${player} was kicked from the party by ${sender.preferredName}.`,
     );
-    await bot.utils.delay(bot.utils.minMsgDelay);
-    bot.chat(`/p kick ${player}`);
+    
     bot.utils.webhookLogger.addMessage(
       `\`${player}\` was kicked from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
       WebhookMessageType.ActionLog,

--- a/src/mineflayer/commands/party/Mute.mjs
+++ b/src/mineflayer/commands/party/Mute.mjs
@@ -3,7 +3,7 @@ import { Permissions, WebhookMessageType } from "../../../utils/Interfaces.mjs";
 export default {
   name: ["mute", "unmute"],
   description: "Mute/Unmute the party",
-  usage: "!p mute",
+  usage: "!p mute [reason]",
   permission: Permissions.Trusted,
 
   /**
@@ -13,10 +13,12 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    let reason = args.join(" ") || "No reason given.";
+    const reason = args.join(" ") || "No reason given.";
+    
     bot.chat("/p mute");
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/pc Party mute was toggled by ${sender.preferredName}.`);
+    
     bot.utils.webhookLogger.addMessage(
       `Party mute was toggled by \`${sender.preferredName}\`. Reason: \`${reason}\``,
       WebhookMessageType.ActionLog,

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -51,8 +51,18 @@ export default {
         );
       }
     }
-    
+
     bot.reply(sender, `Trying to unban ${player}...`, VerbosityLevel.Reduced);
+    
+    if (!registry.isBanned(username)) {
+      return bot.reply(sender, `${username} is not currently banned.`, VerbosityLevel.Reduced);
+    } else {
+      const remaining = getRemainingDuration(registry, player);
+      if (remaining && remaining !== "ban has expired") {
+        registry.removeBan(username);
+        return bot.reply(sender, `${username}'s ban has been reduced from ${remaining} to unbanned.`, VerbosityLevel.Reduced);
+      }
+    }
     
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/lobby`);

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -7,7 +7,7 @@ import {
 export default {
   name: ["unban", "unblock"],
   description: "Unban a player from the party",
-  usage: "!p unban <username>",
+  usage: "!p unban <username> [reason]",
   permission: Permissions.Trusted,
 
   /**
@@ -17,26 +17,52 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    let player;
-    if (args[0]) {
-      player = await bot.utils.usernameExists(args[0]);
-      if (player === false)
-        return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-    } else
-      return bot.reply(
-        sender,
-        `Invalid usage! Use: ${this.usage}`,
-        VerbosityLevel.Reduced,
+    let player = args[0];
+    if (!player) {
+      return bot.reply(sender, `Invalid usage! Use: ${this.usage}`, VerbosityLevel.Reduced);
+    }
+    const playerExists = await bot.utils.usernameExists(player);
+    if (playerExists === false) {
+      return bot.reply(sender, `Player ${player} not found`, VerbosityLevel.Reduced);
+    }
+    const reason = args.slice(1).join(" ") || "No reason given.";
+
+    if (!bot.utils.isHigherRanked(sender.username, player)) {
+      const senderPermsRank = bot.utils.getPermissionsByUser({ name: sender.username });
+      const playerPermsRank = bot.utils.getPermissionsByUser({ name: player });
+      const senderPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === senderPermsRank,
       );
+      const playerPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === playerPermsRank,
+      );
+      if (senderPerms === undefined) return;
+      else if (senderPermsRank === playerPermsRank) {
+        return bot.reply(
+          sender,
+          `You cannot unban a player of the same permission level (both: ${senderPerms}).`,
+          VerbosityLevel.Reduced,
+        );
+      } else {
+        return bot.reply(
+          sender,
+          `You cannot unban a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPermsRank})).`,
+          VerbosityLevel.Reduced,
+        );
+      }
+    }
+    
     bot.reply(sender, `Trying to unban ${player}...`, VerbosityLevel.Reduced);
+    
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/lobby`);
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/block remove ${player}`);
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.reply(sender, `Unbanned ${player}.`, VerbosityLevel.Reduced);
+    
     bot.utils.webhookLogger.addMessage(
-      `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`.`,
+      `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
       WebhookMessageType.ActionLog,
       true,
     );


### PR DESCRIPTION
- reworked some of the logic of the commands to be consistent with one another
- order of the banning process was changed
- added ${player} to the "player not found" chat for all commands
- extended "you cannot ban / unban / kick someone with higher a permission level" in that it includes your and the target player's permission and level
- upon banning, sets permission level of affected user to 0 and logs that to the console

- added default duration for a ban (if no `duration` argument is provided) to 30 days
- additional dialog when attempting to (un)ban a user that's already (un)banned
- _attempt_ at a temporary ban feature with a banRegistry class in Utils.mjs, a setInterval function refreshing every 60 seconds and a dictionary storing the usernames along with ban start and end times (what am i doing?)