### PR TITLE
Update Unban.mjs

### DIFF
--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -36,11 +36,20 @@ export default {
       const playerPerms = Object.keys(Permissions).find(
         (perm) => Permissions[perm] === playerPermsRank,
       );
-      return bot.reply(
-        sender,
-        `You cannot unban a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPerms}).`,
-        VerbosityLevel.Reduced,
-      );
+      if (senderPerms === undefined) return;
+      else if (senderPermsRank === playerPermsRank) {
+        return bot.reply(
+          sender,
+          `You cannot unban a player of the same permission level (both: ${senderPerms}).`,
+          VerbosityLevel.Reduced,
+        );
+      } else {
+        return bot.reply(
+          sender,
+          `You cannot unban a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPermsRank})).`,
+          VerbosityLevel.Reduced,
+        );
+      }
     }
     
     bot.reply(sender, `Trying to unban ${player}...`, VerbosityLevel.Reduced);

--- a/src/mineflayer/commands/party/Unban.mjs
+++ b/src/mineflayer/commands/party/Unban.mjs
@@ -7,7 +7,7 @@ import {
 export default {
   name: ["unban", "unblock"],
   description: "Unban a player from the party",
-  usage: "!p unban <username>",
+  usage: "!p unban <username> [reason]",
   permission: Permissions.Trusted,
 
   /**
@@ -17,26 +17,43 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    let player;
-    if (args[0]) {
-      player = await bot.utils.usernameExists(args[0]);
-      if (player === false)
-        return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-    } else
+    let player = args[0];
+    if (!player) {
+      return bot.reply(sender, `Invalid usage! Use: ${this.usage}`, VerbosityLevel.Reduced);
+    }
+    const playerExists = await bot.utils.usernameExists(player);
+    if (playerExists === false) {
+      return bot.reply(sender, `Player ${player} not found`, VerbosityLevel.Reduced);
+    }
+    const reason = args.slice(1).join(" ") || "No reason given.";
+
+    if (!bot.utils.isHigherRanked(sender.username, player)) {
+      const senderPermsRank = bot.utils.getPermissionsByUser({ name: sender.username });
+      const playerPermsRank = bot.utils.getPermissionsByUser({ name: player });
+      const senderPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === senderPermsRank,
+      );
+      const playerPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === playerPermsRank,
+      );
       return bot.reply(
         sender,
-        `Invalid usage! Use: ${this.usage}`,
+        `You cannot unban a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPerms}).`,
         VerbosityLevel.Reduced,
       );
+    }
+    
     bot.reply(sender, `Trying to unban ${player}...`, VerbosityLevel.Reduced);
+    
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/lobby`);
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(`/block remove ${player}`);
     await bot.utils.delay(bot.utils.minMsgDelay);
     bot.reply(sender, `Unbanned ${player}.`, VerbosityLevel.Reduced);
+    
     bot.utils.webhookLogger.addMessage(
-      `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`.`,
+      `\`${player}\` was unbanned from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
       WebhookMessageType.ActionLog,
       true,
     );


### PR DESCRIPTION
- switched around some of the check logic to be consistent with Ban.mjs
- added `${player}` to the "player not found" chat
- added "you cannot unban someone with higher a permission level" (also includes your and the target player's permission and level)
- added option to provide a reason for the unban