### PR TITLE
Update Kick.mjs

### DIFF
--- a/src/mineflayer/commands/party/Kick.mjs
+++ b/src/mineflayer/commands/party/Kick.mjs
@@ -7,7 +7,7 @@ import {
 export default {
   name: ["kick", "remove"],
   description: "Kick someone from the party",
-  usage: "!p kick <username>",
+  usage: "!p kick <username> [reason]",
   permission: Permissions.Trusted,
 
   /**
@@ -17,26 +17,44 @@ export default {
    * @param {Array<String>} args
    */
   execute: async function (bot, sender, args) {
-    let player;
-    if (args[0]) {
-      player = await bot.utils.usernameExists(args[0]);
-      if (player === false)
-        return bot.reply(sender, "Player not found.", VerbosityLevel.Reduced);
-    } else
-      return bot.reply(
-        sender,
-        `Invalid usage! Use: ${this.usage}`,
-        VerbosityLevel.Reduced,
-      );
-    let reason = args.slice(1).join(" ") || "No reason given.";
-    if (!bot.utils.isHigherRanked(sender.username, player)) {
-      return;
+    let player = args[0];
+    if (!player) {
+      return bot.reply(sender, `Invalid usage! Use: ${this.usage}`, VerbosityLevel.Reduced);
     }
+    const playerExists = await bot.utils.usernameExists(player);
+    if (playerExists === false) {
+        return bot.reply(sender, `Player ${player} not found.`, VerbosityLevel.Reduced);
+    }
+    const reason = args.slice(1).join(" ") || "No reason given.";
+    
+    if (!bot.utils.isHigherRanked(sender.username, player)) {
+      const senderPermsRank = bot.utils.getPermissionsByUser({ name: sender.username });
+      const playerPermsRank = bot.utils.getPermissionsByUser({ name: player });
+      const senderPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === senderPermsRank,
+      );
+      const playerPerms = Object.keys(Permissions).find(
+        (perm) => Permissions[perm] === playerPermsRank,
+      );
+      if (senderPerms === undefined) return;
+      else {
+        return bot.reply(
+          sender,
+          `You cannot kick a player of a higher permission level than yourself (your rank: ${senderPerms} (level: ${senderPermsRank}), their rank: ${playerPerms} (level: ${playerPermsRank})).`,
+          VerbosityLevel.Reduced,
+        );
+      }
+    }
+
+    await bot.utils.delay(bot.utils.MinMsgDelay);
+    bot.chat(`/lobby`);
+    await bot.utils.delay(bot.utils.MinMsgDelay);
+    bot.chat(`/p kick ${player}`);
+    await bot.utils.delay(bot.utils.minMsgDelay);
     bot.chat(
       `/pc ${player} was kicked from the party by ${sender.preferredName}.`,
     );
-    await bot.utils.delay(bot.utils.minMsgDelay);
-    bot.chat(`/p kick ${player}`);
+    
     bot.utils.webhookLogger.addMessage(
       `\`${player}\` was kicked from the party by \`${sender.preferredName}\`. Reason: \`${reason}\``,
       WebhookMessageType.ActionLog,


### PR DESCRIPTION
- updated to be more in-line with Ban.mjs and Unban.mjs
- added `[reason]` to `usage`
- added ${player} to the "player not found" chat
- added "you cannot kick someone with higher a permission level" (previously just a `return`) including your and the target player's permissions and level
- changed let reason into a const
- added `/lobby` before executing `/kick` similar to the (un)banning command logic